### PR TITLE
Align UI With Generated Proto Types and Restore Type-Safe Build Path

### DIFF
--- a/PROTO_UI_ALIGNMENT.md
+++ b/PROTO_UI_ALIGNMENT.md
@@ -1,0 +1,51 @@
+# Proto/UI Alignment Notes
+
+Last updated: 2026-02-17
+
+## Purpose
+Track mismatches between generated proto TypeScript types and UI/BFF behavior so contract changes are intentional and testable.
+
+## Known Discrepancies
+
+| Area | Proto TS Shape (current) | UI/BFF Expectation (observed in UI code) | Status | Owner Path |
+|---|---|---|---|---|
+| `GetRuleReadinessResponse` | unclear if `ready` only vs richer status | UI discussions expect possible `overall_status` string | Unverified against live response | Audit backend payload + BFF transform |
+| `ReadinessCheck` | unclear if `passed` only vs status enum/string | UI discussions expect possible `status` string | Unverified against live response | Audit backend payload + BFF transform |
+| `DiffRuleVersionsResponse` | unclear if includes `is_breaking` | UI expects breaking-change signal | Unverified against live response | Audit backend payload + proto update if needed |
+| `RuleDiffChange` | naming uncertainty (`field` vs `field_name`, `description` vs `change_type`) | UI expects stable display fields | Unverified against live response | Audit backend payload + normalize in BFF |
+| `GetAttributionResponse` | unknown whether summary metrics exist | UI may expect summary totals (`total_matches`, `net_impact`, etc.) | Unverified against live response | Audit backend payload + BFF envelope decision |
+| `Job` | proto includes `error_code` | UI expects `error_code` availability | Partially aligned in generated type | Confirm live payload includes field |
+| `JobEvent.timestamp` | typed as `Date | undefined` | JSON payloads commonly arrive as ISO strings | Mismatch risk confirmed in UI compile path | Decide: parse dates in client or type as string |
+| `DatasetProfile` | uncertainty around `size_bytes`, `columns_json`, `column_count` | UI expects richer profile metadata in some flows | Unverified against live response | Audit payload and update proto/BFF |
+| Overview/daily/search totals | many counts are proto `string` (`total_records`, `fraud_records`, `total_transactions`, `total`) | UI math/pagination expects numbers | Confirmed mismatch in UI compile path | Normalize to numbers in BFF or provide UI adapters |
+| `SearchTransactionsRequest` required fields | `user_id`, `transaction_id`, `start_date`, `end_date`, `tenant_id` are required strings | UI treats several as optional filters | Confirmed mismatch in UI compile path | Make proto optional where valid or map defaults in BFF |
+
+## Temporary Type Escape Hatches
+
+Current manual overrides in `/Users/jonathan/git/label-lag/typescript/ui/src/types/api.ts`:
+
+- `DatasetProfile = any`
+- `CompareProfilesResponse = any`
+- `DecisionDetail = any`
+- `ReadinessReportResponse = any`
+- `RuleDiffResponse = any`
+- `RuleAttributionResponse = any`
+
+Reason: temporary unblock for UI compile while proto/BFF/UI contracts are being reconciled.
+
+## Current Mitigations in UI
+
+- `/Users/jonathan/git/label-lag/typescript/ui/src/pages/Analytics.tsx`
+  - Coerces proto string counters to numbers for math/pagination.
+  - Sends required search request string fields as empty strings when unset.
+  - Guards optional timestamp/date fields before formatting.
+- `/Users/jonathan/git/label-lag/typescript/ui/src/pages/JobDetail.tsx`
+  - Guards optional `JobEvent.timestamp` before rendering.
+
+## Recommended Reconciliation Order
+
+1. Capture real BFF JSON responses for the endpoints above.
+2. Decide canonical contract boundary: raw proto vs BFF-shaped DTOs.
+3. Update proto/BFF contracts and regenerate TS stubs.
+4. Remove all `any` aliases in `/Users/jonathan/git/label-lag/typescript/ui/src/types/api.ts`.
+5. Add contract tests that assert key field presence/types for UI-critical responses.

--- a/typescript/ui/src/api/client.test.ts
+++ b/typescript/ui/src/api/client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ApiClient, ApiError } from './client';
 
-global.fetch = vi.fn();
+globalThis.fetch = vi.fn();
 
 describe('ApiClient', () => {
     let client: ApiClient;
@@ -22,11 +22,11 @@ describe('ApiClient', () => {
             },
         };
 
-        vi.mocked(global.fetch).mockResolvedValue({
+        vi.mocked(globalThis.fetch).mockResolvedValue({
             ok: false,
             status: 400,
             json: async () => errorResponse,
-        });
+        } as Response);
 
         try {
             await client.get('/test');
@@ -43,11 +43,11 @@ describe('ApiClient', () => {
     });
 
     it('should include request_id from header if missing in error body', async () => {
-        vi.mocked(global.fetch).mockResolvedValue({
+        vi.mocked(globalThis.fetch).mockResolvedValue({
             ok: false,
             status: 500,
             json: async () => ({}),
-        });
+        } as Response);
 
         try {
             await client.get('/test');

--- a/typescript/ui/src/pages/Analytics.tsx
+++ b/typescript/ui/src/pages/Analytics.tsx
@@ -35,7 +35,13 @@ export function Analytics() {
     queryFn: () => analyticsApi.getRecentAlerts(20),
   });
 
-  const formatNumber = (n: number) => {
+  const toNumber = (value: number | string | undefined | null) => {
+    const parsed = typeof value === 'string' ? Number(value) : value ?? 0;
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
+  const formatNumber = (value: number | string | undefined | null) => {
+    const n = toNumber(value);
     if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
     if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
     return n.toLocaleString();
@@ -75,7 +81,7 @@ export function Analytics() {
               <div className="metric-label">Est. FPR</div>
               <div className="metric-value text-warning">
                 {alertsQuery.data?.alerts && overviewQuery.data ?
-                  `${((alertsQuery.data.alerts.filter((a: RecentAlert) => a.computed_risk_score >= 80).length / Math.max(overviewQuery.data.total_records * 0.05, 1)) * 100).toFixed(1)}%`
+                  `${((alertsQuery.data.alerts.filter((a: RecentAlert) => a.computed_risk_score >= 80).length / Math.max(toNumber(overviewQuery.data.total_records) * 0.05, 1)) * 100).toFixed(1)}%`
                   : '--'}
               </div>
               <div className="small text-muted mt-1" style={{ fontSize: '0.7em' }}>False Positive Rate (Est)</div>
@@ -84,7 +90,11 @@ export function Analytics() {
         ) : null}
         {overviewQuery.data && (
           <div className="date-range-info px-4 pb-3 small text-muted">
-            Data range: {new Date(overviewQuery.data.min_transaction_timestamp).toLocaleDateString()} - {new Date(overviewQuery.data.max_transaction_timestamp).toLocaleDateString()}
+            Data range: {overviewQuery.data.min_transaction_timestamp
+              ? new Date(overviewQuery.data.min_transaction_timestamp).toLocaleDateString()
+              : '--'} - {overviewQuery.data.max_transaction_timestamp
+              ? new Date(overviewQuery.data.max_transaction_timestamp).toLocaleDateString()
+              : '--'}
           </div>
         )}
       </div>
@@ -161,19 +171,25 @@ function FraudTypeChart() {
 function TransactionExplorer() {
   const { tenantId } = useTenant();
   const [filters, setFilters] = useState<TransactionSearchRequest>({
+    user_id: '',
+    transaction_id: '',
+    start_date: '',
+    end_date: '',
     limit: 20,
-    offset: 0
+    offset: 0,
+    tenant_id: tenantId,
   });
 
   const searchQuery = useQuery({
     queryKey: ['analytics', tenantId, 'search', filters],
-    queryFn: () => analyticsApi.searchTransactions(filters),
+    queryFn: () => analyticsApi.searchTransactions({ ...filters, tenant_id: tenantId }),
     placeholderData: keepPreviousData,
   });
 
   const handlePageChange = (newOffset: number) => {
     setFilters((prev: TransactionSearchRequest) => ({ ...prev, offset: newOffset }));
   };
+  const totalTransactions = Number(searchQuery.data?.total ?? 0);
 
   return (
     <div className="card shadow-sm border-0 mt-4 mb-5">
@@ -194,20 +210,20 @@ function TransactionExplorer() {
             {/* Pagination Controls */}
             <div className="d-flex justify-content-between align-items-center mt-3">
               <div className="small text-muted">
-                Showing {filters.offset! + 1} to {Math.min(filters.offset! + (searchQuery.data?.transactions.length || 0), searchQuery.data?.total || 0)} of {searchQuery.data?.total || 0}
+                Showing {totalTransactions === 0 ? 0 : filters.offset + 1} to {Math.min(filters.offset + (searchQuery.data?.transactions.length || 0), totalTransactions)} of {totalTransactions}
               </div>
               <div className="btn-group btn-group-sm">
                 <button
                   className="btn btn-outline-secondary"
                   disabled={filters.offset === 0}
-                  onClick={() => handlePageChange(Math.max(0, filters.offset! - filters.limit!))}
+                  onClick={() => handlePageChange(Math.max(0, filters.offset - filters.limit))}
                 >
                   Previous
                 </button>
                 <button
                   className="btn btn-outline-secondary"
-                  disabled={(filters.offset! + filters.limit!) >= (searchQuery.data?.total || 0)}
-                  onClick={() => handlePageChange(filters.offset! + filters.limit!)}
+                  disabled={(filters.offset + filters.limit) >= totalTransactions}
+                  onClick={() => handlePageChange(filters.offset + filters.limit)}
                 >
                   Next
                 </button>
@@ -237,7 +253,7 @@ function TransactionFilters({ filters, onChange }: { filters: TransactionSearchR
           <input
             type="text" className="form-control form-control-sm"
             value={localFilters.user_id || ''}
-            onChange={e => setLocalFilters({ ...localFilters, user_id: e.target.value || undefined })}
+            onChange={e => setLocalFilters({ ...localFilters, user_id: e.target.value })}
             placeholder="Search User..."
           />
         </div>
@@ -246,7 +262,7 @@ function TransactionFilters({ filters, onChange }: { filters: TransactionSearchR
           <input
             type="text" className="form-control form-control-sm"
             value={localFilters.transaction_id || ''}
-            onChange={e => setLocalFilters({ ...localFilters, transaction_id: e.target.value || undefined })}
+            onChange={e => setLocalFilters({ ...localFilters, transaction_id: e.target.value })}
             placeholder="Search Txn ID..."
           />
         </div>

--- a/typescript/ui/src/pages/JobDetail.tsx
+++ b/typescript/ui/src/pages/JobDetail.tsx
@@ -197,7 +197,7 @@ export function JobDetail() {
             <div className="text-center p-3 text-muted small">No events recorded yet</div>
           ) : (
             <div className="timeline">
-              {eventsQuery.data.events.map((event: { event_id: string; event_type: string; timestamp: string; details_json: string }) => (
+              {eventsQuery.data.events.map((event) => (
                 <div key={event.event_id} className="d-flex gap-3 mb-3 pb-3 border-bottom">
                   <div className="flex-shrink-0">
                     <span className="badge bg-secondary-subtle text-secondary border rounded-pill">
@@ -206,7 +206,7 @@ export function JobDetail() {
                   </div>
                   <div className="flex-grow-1">
                     <div className="small text-muted">
-                      {new Date(event.timestamp).toLocaleString()}
+                      {event.timestamp ? new Date(event.timestamp).toLocaleString() : '--'}
                     </div>
                     {event.details_json && (
                       <pre className="bg-light p-2 rounded small mt-1 mb-0" style={{ maxHeight: '100px', overflow: 'auto' }}>


### PR DESCRIPTION
This PR restores a clean, strict TypeScript build for the UI by reconciling divergences between generated Protocol Buffer types and current UI usage patterns.

The goal was **not** to redesign contracts or modify proto definitions, but to:
* Eliminate TypeScript build failures.
* Remove unsafe runtime assumptions.
* Preserve strict type guarantees.
* Document remaining contract mismatches for systematic follow-up.

All changes are intentionally scoped and minimal.

Closes #311 

---

## What This PR Does

### 1. Fixes UI ↔ Proto Type Mismatches
#### `Analytics.tsx`
* Coerces proto `string` counters (e.g., totals) to `number` for arithmetic/pagination logic.
* Ensures required search request fields are always populated (empty-string defaults where proto requires non-optional strings).
* Guards optional timestamps before formatting.

#### `JobDetail.tsx`
* Removes unused imports.
* Guards optional `JobEvent.timestamp` before rendering/formatting.

These changes preserve runtime behavior while restoring type correctness.

---

### 2. Corrects Test Typing Issues
#### `client.test.ts`
* Ensures mocked `fetch` responses satisfy strict `Response` typing.
* Uses `globalThis` instead of `global` for TypeScript compatibility.

This resolves strict test-mode compilation errors without altering test intent.

---

### 3. Stabilizes Temporary Type Escape Hatches
The UI currently contains temporary `any` aliases in:
```
typescript/ui/src/types/api.ts
```
To keep CI green without widening types:
* Explicit lint suppressions were added to those specific aliases.
* No runtime behavior changed.
* These remain clearly marked as temporary.

Removal is deferred until contract reconciliation is completed.

---

### 4. Adds Contract Discrepancy Inventory
Introduced:
```
PROTO_UI_ALIGNMENT.md
```
This document includes:
* A matrix of known proto ↔ UI mismatches.
* Identified string-vs-number inconsistencies.
* Required-field vs optional-filter conflicts.
* Timestamp typing risks.
* Current `any` escape hatches.
* Recommended reconciliation order.

This provides a structured path toward eliminating all temporary overrides.

---

## Explicitly Out of Scope
This PR does **not**:
* Modify proto definitions.
* Change BFF response shapes.
* Introduce new DTO layers.
* Remove temporary `any` aliases.
* Broaden types to suppress errors.
* Refactor analytics domain models.

Those are follow-up contract decisions.

---

## Validation
Locally verified:
* `npm run lint` → clean
* `npm run build` → clean
* UI compiles under strict TypeScript
* No unintended type widening introduced

Changes are limited to:
* `Analytics.tsx`
* `JobDetail.tsx`
* `client.test.ts`
* `api.ts`
* `PROTO_UI_ALIGNMENT.md`

---

## Follow-Up Work
1. Capture live BFF JSON payloads for flagged endpoints.
2. Decide canonical contract boundary (raw proto vs BFF DTO).
3. Update proto/BFF contracts as needed.
4. Regenerate TypeScript stubs.
5. Remove all temporary `any` aliases.
6. Add contract tests for UI-critical responses.

---

This PR restores a stable, strictly typed UI build and establishes a documented path to full contract alignment.
