### PR TITLE
feat(python): ML operability health summary and drift error contract

### DIFF
--- a/docs/inference/model_manager_diagnostics_contract.md
+++ b/docs/inference/model_manager_diagnostics_contract.md
@@ -36,7 +36,7 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 | `ml.training.run_id` | `string \| null` | Training run correlation id. |
 | `ml.model.version` | `string \| null` | Training-side model version value. |
 | `ml.feature.schema_hash` | `string \| null` | Training-side feature schema hash. |
-| `config` | `object` | Effective strict-mode runtime config (`strict_feature_schema`, `strict_tuning_resume_validation`, `strict_split_strategy_validation`). |
+| `config` | `object` | Effective strict-mode runtime config (`strict_feature_schema`, `strict_tuning_resume_validation`, `strict_split_strategy_validation`). Also projected to forecast `GetHealth` component flags. |
 | `ml_health` | `object` | Compact bounded operator summary derived from diagnostics + last drift cache snapshot when available. |
 
 ## Nullable Value Conditions (Keys Still Present)
@@ -127,6 +127,12 @@ backward compatibility.
 - `strict_tuning_resume_validation`
 - `strict_split_strategy_validation`
 
+Forecast `GetHealth` strict flag projection:
+
+- Reads `diagnostics.config` when present.
+- Falls back to `diagnostics.ml_health.config` when top-level `config` is missing.
+- Defaults each strict flag to `false` when neither source is available.
+
 Legacy aliases retained in `ml_health`:
 
 - `state`
@@ -185,8 +191,16 @@ Legacy normalization behavior:
 
 - Legacy resolution values (`production_stage`, `latest_version`) are normalized
   to canonical `resolution_mode` (`stage`, `latest`).
+- Canonical `resolution_mode` values (`alias`, `stage`, `latest`, `none`) are
+  passed through unchanged.
+- If top-level `resolution_mode` is missing/invalid, the value is derived from
+  `reference_resolution.resolution_mode` or
+  `reference_resolution.resolution_strategy`.
 - When only legacy error fields are present, canonical `error_code` /
   `error_message` are backfilled.
+- Legacy error-code aliases (for example `insufficient_reference_data`,
+  `no_reference_model`, `no_live_window`) are normalized into canonical
+  `error_code` values.
 - `error_message` is capped at 200 characters.
 
 ## Example Payload

--- a/python/src/forecast/model_manager.py
+++ b/python/src/forecast/model_manager.py
@@ -465,11 +465,14 @@ class ModelManager:
 
     @staticmethod
     def _normalize_resolution_mode(raw_mode: Any) -> str:
-        if raw_mode == "alias":
-            return "alias"
-        if raw_mode == "production_stage":
+        if raw_mode is None:
+            return "none"
+        normalized = str(raw_mode).strip().lower()
+        if normalized in {"alias", "stage", "latest", "none"}:
+            return normalized
+        if normalized == "production_stage":
             return "stage"
-        if raw_mode == "latest_version":
+        if normalized == "latest_version":
             return "latest"
         return "none"
 
@@ -539,11 +542,15 @@ class ModelManager:
 
                 result_payload = getattr(cached_result, "result", {})
                 if isinstance(result_payload, dict):
+                    drift_resolution_mode = self._normalize_resolution_mode(
+                        result_payload.get("resolution_mode")
+                    )
                     resolution = result_payload.get("reference_resolution")
                     if isinstance(resolution, dict):
-                        drift_resolution_mode = self._normalize_resolution_mode(
-                            resolution.get("resolution_strategy")
-                        )
+                        if drift_resolution_mode == "none":
+                            drift_resolution_mode = self._normalize_resolution_mode(
+                                resolution.get("resolution_strategy")
+                            )
                         selected_run_id = resolution.get("selected_run_id")
                         if selected_run_id is not None:
                             drift_reference_available = bool(

--- a/python/src/forecast/service.py
+++ b/python/src/forecast/service.py
@@ -10,6 +10,33 @@ from forecast.v1 import forecast_pb2, forecast_pb2_grpc
 
 logger = logging.getLogger(__name__)
 
+_STRICT_CONFIG_KEYS = (
+    "strict_feature_schema",
+    "strict_tuning_resume_validation",
+    "strict_split_strategy_validation",
+)
+
+
+def _normalize_strict_config(config_snapshot):
+    if not isinstance(config_snapshot, dict):
+        return {key: False for key in _STRICT_CONFIG_KEYS}
+    return {key: bool(config_snapshot.get(key, False)) for key in _STRICT_CONFIG_KEYS}
+
+
+def _extract_effective_strict_config(diagnostics):
+    if not isinstance(diagnostics, dict):
+        return _normalize_strict_config(None)
+
+    direct_config = diagnostics.get("config")
+    if isinstance(direct_config, dict):
+        return _normalize_strict_config(direct_config)
+
+    ml_health = diagnostics.get("ml_health")
+    if isinstance(ml_health, dict):
+        return _normalize_strict_config(ml_health.get("config"))
+
+    return _normalize_strict_config(None)
+
 
 class ForecastService(forecast_pb2_grpc.ForecastServiceServicer):
     def GetHealth(self, request, context):  # noqa: N802
@@ -19,36 +46,21 @@ class ForecastService(forecast_pb2_grpc.ForecastServiceServicer):
             manager.model_version if manager.model_loaded else forecaster.model_version
         )
         diagnostics = manager.get_diagnostics()
-        strict_config = diagnostics.get("config", {})
-        strict_feature_schema = (
-            bool(strict_config.get("strict_feature_schema", False))
-            if isinstance(strict_config, dict)
-            else False
-        )
-        strict_tuning_resume_validation = (
-            bool(strict_config.get("strict_tuning_resume_validation", False))
-            if isinstance(strict_config, dict)
-            else False
-        )
-        strict_split_strategy_validation = (
-            bool(strict_config.get("strict_split_strategy_validation", False))
-            if isinstance(strict_config, dict)
-            else False
+        strict_config = _extract_effective_strict_config(diagnostics)
+        components = {
+            "model_loaded": "true" if manager.model_loaded else "false",
+            "version": version or "unknown",
+        }
+        components.update(
+            {
+                key: ("true" if strict_config[key] else "false")
+                for key in _STRICT_CONFIG_KEYS
+            }
         )
 
         return forecast_pb2.GetHealthResponse(
             status="healthy",
-            components={
-                "model_loaded": "true" if manager.model_loaded else "false",
-                "version": version or "unknown",
-                "strict_feature_schema": ("true" if strict_feature_schema else "false"),
-                "strict_tuning_resume_validation": (
-                    "true" if strict_tuning_resume_validation else "false"
-                ),
-                "strict_split_strategy_validation": (
-                    "true" if strict_split_strategy_validation else "false"
-                ),
-            },
+            components=components,
         )
 
     def GetDriftMonitoring(self, request, context):  # noqa: N802

--- a/python/src/training/detect_drift.py
+++ b/python/src/training/detect_drift.py
@@ -19,6 +19,7 @@ import pandas as pd
 from training.crud_client import get_crud_client
 from training.reason_codes import (
     DRIFT_ERROR_CODES,
+    DRIFT_RESOLUTION_MODES,
     DriftErrorCode,
     DriftFallbackReason,
     DriftResolutionMode,
@@ -115,6 +116,20 @@ _DEFAULT_DRIFT_ERROR_MESSAGES = {
     DriftErrorCode.INSUFFICIENT_BUCKET_MASS.value: (
         "Drift signal suppressed due to insufficient bucket mass"
     ),
+}
+_LEGACY_DRIFT_ERROR_CODE_ALIASES = {
+    "no_reference_model": DriftErrorCode.NO_REFERENCE_DATA.value,
+    "no_reference": DriftErrorCode.NO_REFERENCE_DATA.value,
+    "insufficient_reference_data": (
+        DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value
+    ),
+    "insufficient_reference": DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value,
+    "no_live_window": DriftErrorCode.NO_LIVE_DATA.value,
+    "insufficient_bucket_mass": DriftErrorCode.INSUFFICIENT_BUCKET_MASS.value,
+}
+_LEGACY_RESOLUTION_MODE_ALIASES = {
+    "production_stage": DriftResolutionMode.STAGE.value,
+    "latest_version": DriftResolutionMode.LATEST.value,
 }
 
 
@@ -353,16 +368,19 @@ def _select_reference_model_version(
 
 
 def _normalize_resolution_mode(raw_strategy: Any) -> str:
-    if raw_strategy == "alias":
-        return DriftResolutionMode.ALIAS.value
-    if raw_strategy == "production_stage":
-        return DriftResolutionMode.STAGE.value
-    if raw_strategy == "latest_version":
-        return DriftResolutionMode.LATEST.value
+    if raw_strategy is None:
+        return DriftResolutionMode.NONE.value
+    normalized = str(raw_strategy).strip().lower()
+    if normalized in DRIFT_RESOLUTION_MODES:
+        return normalized
+    if normalized in _LEGACY_RESOLUTION_MODE_ALIASES:
+        return _LEGACY_RESOLUTION_MODE_ALIASES[normalized]
     return DriftResolutionMode.NONE.value
 
 
 def _bounded_error_message(message: Any) -> str:
+    if message is None:
+        return ""
     return str(message).strip()[:MAX_DRIFT_ERROR_MESSAGE_LENGTH]
 
 
@@ -384,9 +402,12 @@ def _normalize_error_code(raw_code: Any) -> str | None:
     normalized = str(raw_code).strip()
     if not normalized:
         return None
-    if normalized in DRIFT_ERROR_CODES:
-        return normalized
-    if normalized == DriftFallbackReason.INSUFFICIENT_BUCKET_MASS.value:
+    lowered = normalized.lower()
+    if lowered in DRIFT_ERROR_CODES:
+        return lowered
+    if lowered in _LEGACY_DRIFT_ERROR_CODE_ALIASES:
+        return _LEGACY_DRIFT_ERROR_CODE_ALIASES[lowered]
+    if lowered == DriftFallbackReason.INSUFFICIENT_BUCKET_MASS.value:
         return DriftErrorCode.INSUFFICIENT_BUCKET_MASS.value
     return None
 
@@ -416,7 +437,8 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
         reference_resolution = results.get("reference_resolution")
         if isinstance(reference_resolution, dict):
             normalized_resolution_mode = _normalize_resolution_mode(
-                reference_resolution.get("resolution_strategy")
+                reference_resolution.get("resolution_mode")
+                or reference_resolution.get("resolution_strategy")
             )
     results["resolution_mode"] = normalized_resolution_mode
 
@@ -433,8 +455,12 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
         error_message = _DEFAULT_DRIFT_ERROR_MESSAGES.get(error_code)
     if error_message is not None:
         bounded_error_message = _bounded_error_message(error_message)
-        results["error_message"] = bounded_error_message
-        results["error"] = bounded_error_message
+        if bounded_error_message:
+            results["error_message"] = bounded_error_message
+            results["error"] = bounded_error_message
+        else:
+            results["error_message"] = None
+            results["error"] = None
     else:
         results["error_message"] = None
 

--- a/python/tests/inference/test_model_manager_diagnostics.py
+++ b/python/tests/inference/test_model_manager_diagnostics.py
@@ -1,4 +1,6 @@
 import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -165,3 +167,78 @@ class TestModelManagerDiagnostics:
         recovered = manager.get_diagnostics()
         assert recovered["feature_coverage_last_ratio"] == 1.0
         assert recovered["ml_health"]["feature_coverage"]["last_ratio"] == 1.0
+
+    def test_ml_health_summary_shape_is_stable_and_bounded(self):
+        manager = self._fresh_manager()
+        manager.update_feature_coverage_warning(
+            active=True, observed_ts=111.5, ratio=0.5
+        )
+        mock_cache = SimpleNamespace(
+            _cache=SimpleNamespace(
+                computed_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                result={
+                    "resolution_mode": "stage",
+                    "error_code": "no_reference_data",
+                    "reference_resolution": {"selected_run_id": "run-1"},
+                },
+            )
+        )
+
+        with patch("forecast.drift_cache.get_drift_cache", return_value=mock_cache):
+            health = manager.get_diagnostics()["ml_health"]
+
+        assert {"model", "benchmark", "drift", "feature_coverage"}.issubset(
+            health.keys()
+        )
+        assert set(health["model"].keys()) == {
+            "state",
+            "active_model_version",
+            "last_reload_status",
+            "last_reload_ts",
+            "schema_mismatch_detected",
+        }
+        assert set(health["benchmark"].keys()) == {
+            "enabled",
+            "last_status",
+            "last_run_ts",
+        }
+        assert set(health["drift"].keys()) == {
+            "reference_resolution_mode",
+            "last_error_code",
+        }
+        assert set(health["feature_coverage"].keys()) == {
+            "last_ratio",
+            "below_threshold",
+        }
+
+        assert isinstance(health["model"]["state"], str)
+        assert isinstance(health["model"]["active_model_version"], str)
+        assert isinstance(health["model"]["last_reload_status"], str)
+        assert health["model"]["last_reload_ts"] is None or isinstance(
+            health["model"]["last_reload_ts"], float
+        )
+        assert isinstance(health["model"]["schema_mismatch_detected"], bool)
+        assert isinstance(health["benchmark"]["enabled"], bool)
+        assert health["benchmark"]["last_status"] is None or isinstance(
+            health["benchmark"]["last_status"], str
+        )
+        assert health["benchmark"]["last_run_ts"] is None or isinstance(
+            health["benchmark"]["last_run_ts"], float
+        )
+        assert health["drift"]["reference_resolution_mode"] in {
+            "alias",
+            "stage",
+            "latest",
+            "none",
+        }
+        assert health["drift"]["last_error_code"] is None or isinstance(
+            health["drift"]["last_error_code"], str
+        )
+        assert health["feature_coverage"]["last_ratio"] is None or isinstance(
+            health["feature_coverage"]["last_ratio"], float
+        )
+        assert isinstance(health["feature_coverage"]["below_threshold"], bool)
+
+        for value in health.values():
+            if isinstance(value, list):
+                assert len(value) <= 3

--- a/python/tests/test_detect_drift.py
+++ b/python/tests/test_detect_drift.py
@@ -843,6 +843,20 @@ class TestDetectDrift:
                 "expected_code": None,
                 "expected_mode": DriftResolutionMode.ALIAS.value,
             },
+            {
+                "name": "success_stage_mode_from_canonical_reference_metadata",
+                "reference_payload": (
+                    stable_df,
+                    {
+                        "resolution_mode": "stage",
+                        "selected_model_version": "7",
+                        "selected_run_id": "run-v7",
+                    },
+                ),
+                "live_payload": stable_df.copy(),
+                "expected_code": None,
+                "expected_mode": DriftResolutionMode.STAGE.value,
+            },
         ]
 
         for scenario in scenarios:
@@ -879,3 +893,23 @@ class TestDetectDrift:
         assert result["error"] == result["error_message"]
         assert result["resolution_mode"] == DriftResolutionMode.STAGE.value
         assert result["reference_model_version"] == "9"
+
+    def test_drift_error_contract_maps_legacy_alias_error_codes(self):
+        legacy = {
+            "drift_error": None,
+            "error_code": "insufficient_reference_data",
+            "error_message": None,
+            "error": None,
+            "resolution_mode": "latest",
+            "reference_model_version": " 11 ",
+        }
+
+        result = _finalize_drift_error_contract(legacy)
+
+        assert (
+            result["error_code"] == DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value
+        )
+        assert result["error_message"] == "Insufficient reference data"
+        assert result["error"] == "Insufficient reference data"
+        assert result["resolution_mode"] == DriftResolutionMode.LATEST.value
+        assert result["reference_model_version"] == "11"

--- a/python/tests/test_obs_health_service.py
+++ b/python/tests/test_obs_health_service.py
@@ -14,6 +14,14 @@ def _manager_with_config(config: dict[str, bool]):
     )
 
 
+def _manager_with_diagnostics(payload: dict):
+    return SimpleNamespace(
+        model_version="v1",
+        model_loaded=True,
+        get_diagnostics=lambda: payload,
+    )
+
+
 def test_health_components_default_strict_flags_false():
     manager = _manager_with_config(
         {
@@ -54,3 +62,43 @@ def test_health_components_reflect_enabled_strict_flags():
     assert response.components["strict_feature_schema"] == "true"
     assert response.components["strict_tuning_resume_validation"] == "true"
     assert response.components["strict_split_strategy_validation"] == "true"
+
+
+def test_health_components_use_ml_health_config_fallback_when_top_level_missing():
+    manager = _manager_with_diagnostics(
+        {
+            "ml_health": {
+                "config": {
+                    "strict_feature_schema": True,
+                    "strict_tuning_resume_validation": True,
+                    "strict_split_strategy_validation": True,
+                }
+            }
+        }
+    )
+    forecaster = SimpleNamespace(model_version="unknown")
+
+    with (
+        patch("forecast.service.get_model_manager", return_value=manager),
+        patch("forecast.service.get_forecaster", return_value=forecaster),
+    ):
+        response = ForecastService().GetHealth(request=None, context=None)
+
+    assert response.components["strict_feature_schema"] == "true"
+    assert response.components["strict_tuning_resume_validation"] == "true"
+    assert response.components["strict_split_strategy_validation"] == "true"
+
+
+def test_health_components_default_false_when_config_missing_everywhere():
+    manager = _manager_with_diagnostics({"ml_health": {}})
+    forecaster = SimpleNamespace(model_version="unknown")
+
+    with (
+        patch("forecast.service.get_model_manager", return_value=manager),
+        patch("forecast.service.get_forecaster", return_value=forecaster),
+    ):
+        response = ForecastService().GetHealth(request=None, context=None)
+
+    assert response.components["strict_feature_schema"] == "false"
+    assert response.components["strict_tuning_resume_validation"] == "false"
+    assert response.components["strict_split_strategy_validation"] == "false"

--- a/python/tests/test_operability_contract_shapes.py
+++ b/python/tests/test_operability_contract_shapes.py
@@ -78,12 +78,41 @@ def test_ml_health_contract_shape_and_bounds():
         "last_error_code",
     }
     assert set(health["feature_coverage"].keys()) == {"last_ratio", "below_threshold"}
+    assert isinstance(health["model"]["state"], str)
+    assert isinstance(health["model"]["active_model_version"], str)
+    assert isinstance(health["model"]["last_reload_status"], str)
+    assert health["model"]["last_reload_ts"] is None or isinstance(
+        health["model"]["last_reload_ts"], float
+    )
+    assert isinstance(health["model"]["schema_mismatch_detected"], bool)
+    assert isinstance(health["benchmark"]["enabled"], bool)
+    assert health["benchmark"]["last_status"] is None or isinstance(
+        health["benchmark"]["last_status"], str
+    )
+    assert health["benchmark"]["last_run_ts"] is None or isinstance(
+        health["benchmark"]["last_run_ts"], float
+    )
+    assert health["drift"]["reference_resolution_mode"] in {
+        "alias",
+        "stage",
+        "latest",
+        "none",
+    }
+    assert health["drift"]["last_error_code"] is None or isinstance(
+        health["drift"]["last_error_code"], str
+    )
+    assert health["feature_coverage"]["last_ratio"] is None or isinstance(
+        health["feature_coverage"]["last_ratio"], float
+    )
+    assert isinstance(health["feature_coverage"]["below_threshold"], bool)
     assert len(health["active_model_version"]) <= 64
     assert len(health["last_reload_status"]) <= 32
     assert (
         health["drift_last_error_code"] is None
         or len(health["drift_last_error_code"]) <= 64
     )
+    for value in health.values():
+        assert not isinstance(value, list | tuple | set)
 
 
 @patch("training.detect_drift.get_reference_data")
@@ -143,3 +172,35 @@ def test_drift_contract_shape_and_bounds(mock_live, mock_ref):
         breakpoints = feature_result["bucketing"].get("breakpoints")
         if isinstance(breakpoints, list):
             assert len(breakpoints) <= 20
+
+
+@patch("training.detect_drift.get_reference_data")
+@patch("training.detect_drift.get_live_data")
+def test_drift_error_contract_shape_and_bounds(mock_live, mock_ref):
+    mock_ref.return_value = None
+    mock_live.return_value = pd.DataFrame()
+
+    result = detect_drift()
+
+    assert set(result.keys()) == {
+        "timestamp",
+        "hours_analyzed",
+        "threshold",
+        "reference_size",
+        "live_size",
+        "features",
+        "drift_detected",
+        "drifted_features",
+        "drift_error",
+        "error_code",
+        "error_message",
+        "resolution_mode",
+        "alerts",
+        "reference_resolution",
+        "reference_model_version",
+        "error",
+    }
+    assert result["error_code"] == "no_reference_data"
+    assert isinstance(result["error_message"], str)
+    assert len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
+    assert result["error"] == result["error_message"]


### PR DESCRIPTION
## Summary by phase
- Phase 0: captured clean baseline checkpoint and validated repository baseline with full `uv run pytest -q`.
- Phase 1: hardened `ModelManager` ML health summary derivation to normalize drift resolution metadata from canonical and legacy drift cache signals; added inference contract tests for bounded/stable shape.
- Phase 2: surfaced effective strict-mode flags more robustly in forecast health diagnostics projection with fallback to `diagnostics.ml_health.config`; added observability tests for defaults and fallback behavior.
- Phase 3: standardized drift contract normalization for `error_code`, `error_message`, and `resolution_mode` across canonical and legacy inputs; expanded drift failure-mode coverage.
- Phase 4: added stronger golden contract-shape assertions for ML health and drift outputs (including bounded error message checks on error paths).
- Phase 5: updated diagnostics contract docs for ML health summary semantics, strict-config projection behavior, and drift canonical/legacy normalization rules.

## Compatibility
Additive fields and behavior only; no breaking API changes, no new endpoints, and no new dependencies.

## Test plan
- `uv run pytest -q`

## Risk assessment
Low. Changes are focused on bounded payload normalization, observability surface polish, contract tests, and documentation.

Closes #391
