### PR TITLE
feat(python): ML operability health/contracts tranche

### DIFF
--- a/docs/inference/model_manager_diagnostics_contract.md
+++ b/docs/inference/model_manager_diagnostics_contract.md
@@ -31,6 +31,7 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 | `degraded_reasons` | `list[string]` | Bounded degraded-reason vocabulary. |
 | `active_model_version` | `string` | Backward-compatible alias for currently active model version. |
 | `feature_coverage_warning_active` | `bool` | Coverage warning latch. |
+| `feature_coverage_last_ratio` | `float \| null` | Last observed required-feature coverage ratio, clamped to `[0.0, 1.0]`. |
 | `feature_coverage_warning_last_seen_ts` | `float \| null` | Last warning observation timestamp. |
 | `feature_coverage_last_ratio` | `float \| null` | Last observed inference feature coverage ratio (clamped to `[0.0, 1.0]`). |
 | `ml.training.run_id` | `string \| null` | Training run correlation id. |
@@ -48,6 +49,7 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 | `last_reload_reason` | Null unless `last_reload_status=failed`. |
 | `benchmark_last_run_ts` | Null until benchmark path has run or skipped. |
 | `benchmark_last_status` | Null until benchmark path has run or skipped. |
+| `feature_coverage_last_ratio` | Null until at least one model prediction reports required-feature coverage. |
 | `feature_coverage_warning_last_seen_ts` | Null until coverage warning has been observed. |
 | `feature_coverage_last_ratio` | Null until at least one feature coverage observation has been recorded. |
 | `ml.training.run_id` / `ml.model.version` / `ml.feature.schema_hash` | Null when training identity artifact is unavailable. |
@@ -127,6 +129,9 @@ backward compatibility.
 - `strict_tuning_resume_validation`
 - `strict_split_strategy_validation`
 
+Effective strict config values are normalized from env/runtime values using
+boolean semantics (`1/true/yes/on` => `true`, `0/false/no/off` => `false`).
+
 Forecast `GetHealth` strict flag projection:
 
 - Reads `diagnostics.config` when present.
@@ -158,13 +163,18 @@ Legacy aliases retained in `ml_health`:
 
 `training.detect_drift.detect_drift()` includes additive canonical fields:
 
-- `error_code`: bounded reason code or `null`.
+- `error_code`: bounded reason code or `null` (max 64 chars).
 - `error_message`: short operator-facing message or `null`, capped at 200 chars.
 - `resolution_mode`: canonical reference resolution mode.
 - `reference_model_version`: selected reference model version when available.
 - Legacy fields remain for compatibility:
   - `drift_error` (legacy guardrail/fallback indicator)
   - `error` (legacy error text alias for `error_message`)
+
+Legacy compatibility fields remain:
+
+- `drift_error`: legacy drift code mirror (set when canonical `error_code` is set).
+- `error`: legacy message mirror of `error_message`.
 
 Allowed `error_code` values:
 
@@ -222,6 +232,7 @@ Legacy normalization behavior:
   "degraded_reasons": [],
   "active_model_version": "v17",
   "feature_coverage_warning_active": false,
+  "feature_coverage_last_ratio": 1.0,
   "feature_coverage_warning_last_seen_ts": null,
   "ml.training.run_id": "bf0e9d26c4f94ce5b8ef93f7bdf98b2a",
   "ml.model.version": "17",

--- a/python/src/forecast/model_manager.py
+++ b/python/src/forecast/model_manager.py
@@ -161,6 +161,7 @@ class ModelManager:
         self._benchmark_last_run_ts: float | None = None
         self._benchmark_last_status: str | None = None
         self._feature_coverage_warning_active: bool = False
+        self._feature_coverage_last_ratio: float | None = None
         self._feature_coverage_warning_last_seen_ts: float | None = None
         self._feature_coverage_last_ratio: float | None = None
         self._initialized = True
@@ -505,6 +506,13 @@ class ModelManager:
         except (TypeError, ValueError):
             return None
 
+    @staticmethod
+    def _coerce_ratio_or_none(value: Any) -> float | None:
+        ratio = ModelManager._coerce_float_or_none(value)
+        if ratio is None:
+            return None
+        return max(0.0, min(1.0, ratio))
+
     @classmethod
     def _normalize_feature_coverage_ratio(cls, value: Any) -> float | None:
         ratio = cls._coerce_float_or_none(value)
@@ -613,7 +621,7 @@ class ModelManager:
         }
 
         feature_coverage_summary = {
-            "last_ratio": self._normalize_feature_coverage_ratio(
+            "last_ratio": self._coerce_ratio_or_none(
                 diagnostics_snapshot.get(DIAGNOSTIC_KEY_FEATURE_COVERAGE_LAST_RATIO)
             ),
             "below_threshold": bool(
@@ -763,13 +771,15 @@ class ModelManager:
         self,
         *,
         active: bool,
+        coverage_ratio: float | None = None,
         observed_ts: float | None = None,
         ratio: float | None = None,
     ) -> None:
         """Update coverage warning diagnostics state."""
         with self._lock:
             self._feature_coverage_warning_active = bool(active)
-            normalized_ratio = self._normalize_feature_coverage_ratio(ratio)
+            ratio_input = coverage_ratio if coverage_ratio is not None else ratio
+            normalized_ratio = self._normalize_feature_coverage_ratio(ratio_input)
             if normalized_ratio is not None:
                 self._feature_coverage_last_ratio = normalized_ratio
             if active:

--- a/python/src/forecast/model_manager.py
+++ b/python/src/forecast/model_manager.py
@@ -513,6 +513,20 @@ class ModelManager:
             return None
         return max(0.0, min(1.0, ratio))
 
+    @staticmethod
+    def _coerce_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int | float):
+            return bool(value)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "off", ""}:
+                return False
+        return bool(value)
+
     @classmethod
     def _normalize_feature_coverage_ratio(cls, value: Any) -> float | None:
         ratio = cls._coerce_float_or_none(value)
@@ -525,7 +539,7 @@ class ModelManager:
         if not isinstance(config_snapshot, dict):
             return {key: False for key in cls._STRICT_CONFIG_KEYS}
         return {
-            key: bool(config_snapshot.get(key, False))
+            key: cls._coerce_bool(config_snapshot.get(key, False))
             for key in cls._STRICT_CONFIG_KEYS
         }
 
@@ -676,19 +690,13 @@ class ModelManager:
 
     @staticmethod
     def _effective_strict_config() -> dict[str, bool]:
-        def _env_flag(name: str) -> bool:
-            raw = os.getenv(name)
-            if raw is None:
-                return False
-            return raw.strip().lower() in {"1", "true", "yes", "on"}
-
         return ModelManager._normalize_strict_config(
             {
-                "strict_feature_schema": _env_flag("ENFORCE_MODEL_FEATURES"),
-                "strict_tuning_resume_validation": _env_flag(
+                "strict_feature_schema": os.getenv("ENFORCE_MODEL_FEATURES"),
+                "strict_tuning_resume_validation": os.getenv(
                     "STRICT_TUNING_RESUME_VALIDATION"
                 ),
-                "strict_split_strategy_validation": _env_flag(
+                "strict_split_strategy_validation": os.getenv(
                     "STRICT_SPLIT_STRATEGY_VALIDATION"
                 ),
             }

--- a/python/src/forecast/services.py
+++ b/python/src/forecast/services.py
@@ -315,7 +315,7 @@ class SignalForecaster:
                 if hasattr(manager, "update_feature_coverage_warning"):
                     manager.update_feature_coverage_warning(
                         active=coverage_warning_active,
-                        ratio=coverage_ratio,
+                        coverage_ratio=coverage_ratio,
                     )
 
                 log_data = {

--- a/python/src/training/detect_drift.py
+++ b/python/src/training/detect_drift.py
@@ -131,6 +131,7 @@ _LEGACY_RESOLUTION_MODE_ALIASES = {
     "production_stage": DriftResolutionMode.STAGE.value,
     "latest_version": DriftResolutionMode.LATEST.value,
 }
+MAX_DRIFT_ERROR_CODE_LENGTH = 64
 
 
 def calculate_psi(
@@ -384,6 +385,15 @@ def _bounded_error_message(message: Any) -> str:
     return str(message).strip()[:MAX_DRIFT_ERROR_MESSAGE_LENGTH]
 
 
+def _bounded_error_code(code: Any) -> str | None:
+    if code is None:
+        return None
+    rendered = str(code).strip()
+    if not rendered:
+        return None
+    return rendered[:MAX_DRIFT_ERROR_CODE_LENGTH]
+
+
 def _set_canonical_error(
     results: dict[str, Any],
     *,
@@ -391,9 +401,12 @@ def _set_canonical_error(
     message: Any,
 ) -> None:
     bounded_message = _bounded_error_message(message)
+    bounded_code = _bounded_error_code(code.value) or code.value
     results["error"] = bounded_message
-    results["error_code"] = code.value
+    results["error_code"] = bounded_code
     results["error_message"] = bounded_message
+    if results.get("drift_error") is None:
+        results["drift_error"] = bounded_code
 
 
 def _normalize_error_code(raw_code: Any) -> str | None:
@@ -724,7 +737,7 @@ def main() -> int:
     if args.json:
         print(json.dumps(results, indent=2))
 
-    if "error" in results:
+    if results.get("error_code") is not None:
         return 2
     if results["drift_detected"]:
         return 1

--- a/python/src/training/reason_codes.py
+++ b/python/src/training/reason_codes.py
@@ -124,6 +124,7 @@ DIAGNOSTIC_KEY_BENCHMARK_LAST_STATUS = "benchmark_last_status"
 DIAGNOSTIC_KEY_DEGRADED_REASONS = "degraded_reasons"
 DIAGNOSTIC_KEY_ACTIVE_MODEL_VERSION = "active_model_version"
 DIAGNOSTIC_KEY_FEATURE_COVERAGE_WARNING_ACTIVE = "feature_coverage_warning_active"
+DIAGNOSTIC_KEY_FEATURE_COVERAGE_LAST_RATIO = "feature_coverage_last_ratio"
 DIAGNOSTIC_KEY_FEATURE_COVERAGE_WARNING_LAST_SEEN_TS = (
     "feature_coverage_warning_last_seen_ts"
 )

--- a/python/tests/forecast/test_coverage_metrics.py
+++ b/python/tests/forecast/test_coverage_metrics.py
@@ -142,3 +142,20 @@ class TestCoverageMetrics:
             forecaster._predict_with_model(mock_manager, features)
 
         mock_labels.assert_not_called()
+
+    def test_coverage_ratio_forwarded_to_manager_diagnostics(
+        self, forecaster, mock_manager
+    ):
+        """Coverage ratio should be forwarded for diagnostics health summaries."""
+        mock_manager.required_features = ["velocity_24h", "merchant_risk_score"]
+        features = FeatureVector()
+        features.velocity_24h = 10
+        features.merchant_risk_score = None
+        forecaster._calculate_probability = MagicMock(return_value=0.1)
+
+        forecaster._predict_with_model(mock_manager, features)
+
+        mock_manager.update_feature_coverage_warning.assert_called_once_with(
+            active=True,
+            coverage_ratio=0.5,
+        )

--- a/python/tests/test_detect_drift.py
+++ b/python/tests/test_detect_drift.py
@@ -677,6 +677,8 @@ class TestDetectDrift:
         assert result["error_code"] == DriftErrorCode.NO_REFERENCE_DATA.value
         assert result["error_message"] == "No reference data available"
         assert len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
+        assert result["drift_error"] == DriftErrorCode.NO_REFERENCE_DATA.value
+        assert result["error"] == result["error_message"]
         assert result["resolution_mode"] == DriftResolutionMode.NONE.value
         assert result["reference_model_version"] is None
 
@@ -701,6 +703,9 @@ class TestDetectDrift:
         )
         assert "Insufficient reference data" in result["error_message"]
         assert len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
+        assert (
+            result["drift_error"] == DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value
+        )
         assert result["resolution_mode"] == DriftResolutionMode.NONE.value
         assert result["reference_model_version"] is None
 
@@ -735,6 +740,7 @@ class TestDetectDrift:
             == "Drift signal suppressed due to insufficient bucket mass"
         )
         assert len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
+        assert result["drift_error"] == DriftErrorCode.INSUFFICIENT_BUCKET_MASS.value
         assert result["resolution_mode"] in {
             DriftResolutionMode.ALIAS.value,
             DriftResolutionMode.STAGE.value,
@@ -913,3 +919,41 @@ class TestDetectDrift:
         assert result["error"] == "Insufficient reference data"
         assert result["resolution_mode"] == DriftResolutionMode.LATEST.value
         assert result["reference_model_version"] == "11"
+
+    @pytest.mark.parametrize(
+        ("raw_mode", "expected_mode"),
+        [
+            ("alias", DriftResolutionMode.ALIAS.value),
+            ("production_stage", DriftResolutionMode.STAGE.value),
+            ("stage", DriftResolutionMode.STAGE.value),
+            ("latest_version", DriftResolutionMode.LATEST.value),
+            ("latest", DriftResolutionMode.LATEST.value),
+            ("unexpected_mode", DriftResolutionMode.NONE.value),
+        ],
+    )
+    @patch("training.detect_drift.get_reference_data")
+    @patch("training.detect_drift.get_live_data")
+    def test_resolution_mode_is_normalized(
+        self, mock_live, mock_ref, raw_mode, expected_mode
+    ):
+        base = np.arange(1000, dtype=float)
+        stable_reference = pd.DataFrame(
+            {
+                "velocity_24h": base,
+                "amount_to_avg_ratio_30d": base * 0.5,
+                "balance_volatility_z_score": base - 500.0,
+            }
+        )
+        mock_ref.return_value = (
+            stable_reference,
+            {
+                "resolution_strategy": raw_mode,
+                "selected_model_version": "9",
+                "selected_run_id": "run-v9",
+            },
+        )
+        mock_live.return_value = stable_reference.copy()
+
+        result = detect_drift()
+
+        assert result["resolution_mode"] == expected_mode

--- a/python/tests/test_model_manager_defaults.py
+++ b/python/tests/test_model_manager_defaults.py
@@ -201,3 +201,25 @@ def test_ml_health_summary_is_stable_and_bounded():
         for key, value in health.items()
         if key not in {"config", "model", "benchmark", "drift", "feature_coverage"}
     )
+
+
+def test_ml_health_feature_coverage_ratio_tracks_last_observation():
+    manager = _fresh_manager()
+    manager.update_feature_coverage_warning(
+        active=True,
+        coverage_ratio=1.25,
+        observed_ts=123.0,
+    )
+
+    diagnostics = manager.get_diagnostics()
+    health = diagnostics["ml_health"]
+
+    assert diagnostics["feature_coverage_last_ratio"] == 1.0
+    assert health["feature_coverage"]["last_ratio"] == 1.0
+    assert health["feature_coverage"]["below_threshold"] is True
+
+    manager.update_feature_coverage_warning(active=False, coverage_ratio=-0.2)
+    refreshed = manager.get_ml_health_summary()
+
+    assert refreshed["feature_coverage"]["last_ratio"] == 0.0
+    assert refreshed["feature_coverage"]["below_threshold"] is False

--- a/python/tests/test_obs_diagnostics_config.py
+++ b/python/tests/test_obs_diagnostics_config.py
@@ -46,3 +46,21 @@ def test_diagnostics_config_reflects_enabled_strict_flags(monkeypatch):
     assert manager.get_ml_health_summary()["config"] == expected
     assert set(diagnostics["config"].keys()) == set(expected.keys())
     assert all(isinstance(value, bool) for value in diagnostics["config"].values())
+
+
+def test_diagnostics_config_parses_false_like_env_values(monkeypatch):
+    monkeypatch.setenv("ENFORCE_MODEL_FEATURES", "false")
+    monkeypatch.setenv("STRICT_TUNING_RESUME_VALIDATION", "0")
+    monkeypatch.setenv("STRICT_SPLIT_STRATEGY_VALIDATION", "off")
+
+    manager = _fresh_manager()
+    diagnostics = manager.get_diagnostics()
+
+    expected = {
+        "strict_feature_schema": False,
+        "strict_tuning_resume_validation": False,
+        "strict_split_strategy_validation": False,
+    }
+    assert diagnostics["config"] == expected
+    assert diagnostics["ml_health"]["config"] == expected
+    assert manager.get_ml_health_summary()["config"] == expected

--- a/python/tests/test_operability_contract_shapes.py
+++ b/python/tests/test_operability_contract_shapes.py
@@ -13,6 +13,7 @@ from training.detect_drift import (
     MONITORED_FEATURES,
     detect_drift,
 )
+from training.reason_codes import DriftErrorCode, DriftResolutionMode
 
 
 def _fresh_manager() -> ModelManager:
@@ -22,7 +23,11 @@ def _fresh_manager() -> ModelManager:
 
 def test_ml_health_contract_shape_and_bounds():
     manager = _fresh_manager()
-    manager.update_feature_coverage_warning(active=True, observed_ts=111.5)
+    manager.update_feature_coverage_warning(
+        active=True,
+        coverage_ratio=3.5,
+        observed_ts=111.5,
+    )
 
     mock_cache = SimpleNamespace(
         _cache=SimpleNamespace(
@@ -105,6 +110,8 @@ def test_ml_health_contract_shape_and_bounds():
         health["feature_coverage"]["last_ratio"], float
     )
     assert isinstance(health["feature_coverage"]["below_threshold"], bool)
+    assert health["feature_coverage"]["last_ratio"] == 1.0
+    assert 0.0 <= health["feature_coverage"]["last_ratio"] <= 1.0
     assert len(health["active_model_version"]) <= 64
     assert len(health["last_reload_status"]) <= 32
     assert (
@@ -200,7 +207,10 @@ def test_drift_error_contract_shape_and_bounds(mock_live, mock_ref):
         "reference_model_version",
         "error",
     }
-    assert result["error_code"] == "no_reference_data"
+    assert result["error_code"] == DriftErrorCode.NO_REFERENCE_DATA.value
+    assert len(result["error_code"]) <= 64
     assert isinstance(result["error_message"], str)
+    assert result["error_message"] == "No reference data available"
     assert len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
     assert result["error"] == result["error_message"]
+    assert result["resolution_mode"] == DriftResolutionMode.NONE.value


### PR DESCRIPTION
## Summary
- rebase  onto latest 
- preserve and merge ML health/drift contract updates with current mainline behavior
- include conflict resolutions across inference, drift logic, tests, and docs

## Validation
- ..............                                                           [100%]
================================ tests coverage ================================
______________ coverage: platform darwin, python 3.12.12-final-0 _______________

Name                                              Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------------------------------
python/src/features/__init__.py                       2      2      0      0     0%   1-3
python/src/features/registry.py                      21     21      2      0     0%   3-76
python/src/features/spec.py                          16     16      0      0     0%   1-26
python/src/features/store.py                         81     81     14      0     0%   3-160
python/src/forecast/drift_cache.py                   48     16     10      1    60%   30-33, 67-81, 91-92, 100
python/src/forecast/model_manager.py                814    546    282     33    29%   84-89, 131->136, 133->136, 141, 183-194, 199-202, 209, 213, 219-223, 240-254, 261-268, 273-303, 308-322, 328-340, 348-354, 362-366, 376-378, 381, 387-388, 395, 401-411, 418-420, 424, 431-433, 437, 444, 450-465, 474-478, 486, 493, 501, 504-507, 513, 521, 523-527, 534, 540, 562->565, 566->593, 571->582, 572->576, 577->582, 585-591, 723, 725, 791->793, 807-884, 892-1021, 1029-1058, 1062-1080, 1084-1105, 1113-1134, 1142-1161, 1166-1171, 1176-1181, 1185-1204, 1224-1347, 1352-1353, 1361-1395, 1403-1413, 1427-1462, 1478-1506, 1520-1587, 1601-1603
python/src/forecast/service.py                      110    110     22      0     0%   1-216
python/src/forecast/services.py                     224    131     68      9    36%   42-46, 56, 59-61, 115-240, 245, 282-283, 296, 313, 315->321, 329->332, 338, 353-376, 394, 420-459, 471-480, 503-534, 548-550
python/src/inference/__init__.py                      5      5      2      0     0%   3-9
python/src/inference/config.py                       48     48     14      0     0%   3-76
python/src/inference/logging.py                       3      3      0      0     0%   3-7
python/src/inference/server.py                       34     34      6      0     0%   3-64
python/src/inference/service.py                      54     54     10      0     0%   3-118
python/src/logging_util.py                           13     13      2      0     0%   3-72
python/src/main.py                                   47     47      8      0     0%   3-133
python/src/model/__init__.py                          3      3      0      0     0%   3-6
python/src/model/evaluate.py                        140    140     20      0     0%   3-442
python/src/model/loader.py                           98     98     34      0     0%   3-238
python/src/model/split_strategies.py                 75     75     12      0     0%   3-186
python/src/model/train.py                           483    483    136      0     0%   3-994
python/src/model/tuning.py                          310    310    132      0     0%   3-730
python/src/training/audit.py                         90     90     20      0     0%   3-224
python/src/training/config.py                        12     12      0      0     0%   3-19
python/src/training/crud_client.py                  222    164     52      0    21%   34, 50-58, 63-76, 80, 83, 91-97, 100-102, 106-107, 117-118, 126-127, 147-158, 166-171, 176-177, 185-188, 204-227, 231-232, 242-243, 252-253, 262-263, 271-272, 280-281, 294-298, 308-311, 324-377, 381-409, 420-501, 511-515, 521-522, 528-529
python/src/training/detect_drift.py                 348    144    134     21    56%   86-92, 149-150, 153-157, 162-164, 179, 184, 256-259, 264-273, 291-368, 384, 390, 393, 417, 423-425, 431-442, 451->456, 475-476, 494-541, 546-574, 610->612, 643-648, 654, 683-684, 698-699, 722-723, 729-744, 748
python/src/training/gateway_client.py                19     19      4      0     0%   1-35
python/src/training/gateway_grpc_client.py           76     76     16      0     0%   1-193
python/src/training/grpc_errors.py                    6      6      2      0     0%   3-17
python/src/training/inference_backend_config.py      12     12      2      0     0%   16-50
python/src/training/job_queue.py                     30     30      4      0     0%   1-38
python/src/training/job_store.py                    134    134     52      0     0%   1-221
python/src/training/jobs.py                          64     64      8      0     0%   1-88
python/src/training/materialize_features.py          26     26      4      0     0%   3-52
python/src/training/metrics.py                       12     12      0      0     0%   3-31
python/src/training/optuna_resume.py                 74     74     20      0     0%   1-166
python/src/training/postgres_job_store.py           137    137     28      0     0%   1-483
python/src/training/schemas.py                      311      3      4      0    98%   368-370
python/src/training/server.py                        52     52      4      0     0%   3-102
python/src/training/service.py                      618    618    218      0     0%   1-1419
python/src/training/tuning_startup.py                79     79     18      0     0%   1-157
python/src/training/worker.py                       220    220     60      0     0%   1-352
---------------------------------------------------------------------------------------------
TOTAL                                              5290   4208   1424     64    18%

7 files skipped due to complete coverage.
14 passed in 2.95s