### PR TITLE
fix(python): ML operability contract polish v4

### DIFF
--- a/docs/inference/model_manager_diagnostics_contract.md
+++ b/docs/inference/model_manager_diagnostics_contract.md
@@ -1,4 +1,4 @@
-# ModelManager Diagnostics Snapshot Contract
+# ML Operability Payload Contract
 
 This contract describes the payload returned by
 `forecast.model_manager.ModelManager.get_diagnostics()`.
@@ -31,7 +31,6 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 | `degraded_reasons` | `list[string]` | Bounded degraded-reason vocabulary. |
 | `active_model_version` | `string` | Backward-compatible alias for currently active model version. |
 | `feature_coverage_warning_active` | `bool` | Coverage warning latch. |
-| `feature_coverage_last_ratio` | `float \| null` | Last observed required-feature coverage ratio, clamped to `[0.0, 1.0]`. |
 | `feature_coverage_warning_last_seen_ts` | `float \| null` | Last warning observation timestamp. |
 | `feature_coverage_last_ratio` | `float \| null` | Last observed inference feature coverage ratio (clamped to `[0.0, 1.0]`). |
 | `ml.training.run_id` | `string \| null` | Training run correlation id. |
@@ -49,7 +48,6 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 | `last_reload_reason` | Null unless `last_reload_status=failed`. |
 | `benchmark_last_run_ts` | Null until benchmark path has run or skipped. |
 | `benchmark_last_status` | Null until benchmark path has run or skipped. |
-| `feature_coverage_last_ratio` | Null until at least one model prediction reports required-feature coverage. |
 | `feature_coverage_warning_last_seen_ts` | Null until coverage warning has been observed. |
 | `feature_coverage_last_ratio` | Null until at least one feature coverage observation has been recorded. |
 | `ml.training.run_id` / `ml.model.version` / `ml.feature.schema_hash` | Null when training identity artifact is unavailable. |
@@ -159,22 +157,68 @@ Legacy aliases retained in `ml_health`:
 - `null` before first coverage observation.
 - Mirrors root diagnostic `feature_coverage_last_ratio`.
 
-## Drift Error Fields (Canonical)
+## Drift Result Contract
 
-`training.detect_drift.detect_drift()` includes additive canonical fields:
+`training.detect_drift.detect_drift()` returns the same top-level core shape for
+success and failure modes.
+
+Core top-level keys (always present):
+
+- `timestamp`
+- `hours_analyzed`
+- `threshold`
+- `reference_size`
+- `live_size`
+- `features`
+- `drift_detected`
+- `drifted_features`
+- `drift_error`
+- `error_code`
+- `error_message`
+- `error`
+- `resolution_mode`
+- `alerts`
+- `reference_resolution`
+- `reference_model_version`
+
+Field semantics:
 
 - `error_code`: bounded reason code or `null` (max 64 chars).
 - `error_message`: short operator-facing message or `null`, capped at 200 chars.
+- `error`: legacy alias that mirrors `error_message` (`null` on no-error paths).
 - `resolution_mode`: canonical reference resolution mode.
 - `reference_model_version`: selected reference model version when available.
-- Legacy fields remain for compatibility:
-  - `drift_error` (legacy guardrail/fallback indicator)
-  - `error` (legacy error text alias for `error_message`)
-
-Legacy compatibility fields remain:
-
 - `drift_error`: legacy drift code mirror (set when canonical `error_code` is set).
-- `error`: legacy message mirror of `error_message`.
+
+`reference_resolution` shape (always present):
+
+- `requested_alias`: string or `null`
+- `resolution_strategy`: canonical mode (`alias`/`stage`/`latest`/`none`)
+- `resolution_mode`: canonical mode (`alias`/`stage`/`latest`/`none`)
+- `alias_candidate_count`: integer (`0` when none)
+- `alias_ambiguous`: boolean
+- `selected_model_version`: string or `null`
+- `selected_run_id`: string or `null`
+
+`features.<feature_name>` shape (for included monitored features):
+
+- `psi`: float
+- `status`: `OK` / `WARNING` / `CRITICAL`
+- `drift_error`: string or `null`
+- `bucketing`: normalized metadata map with bounded keys:
+  - `buckettype_requested`
+  - `buckettype_used`
+  - `buckets_requested`
+  - `buckets_used`
+  - `bucketing_fallback_reason`
+  - `reference_sample_size`
+  - `nonempty_buckets`
+  - `nonempty_buckets_ratio`
+  - `min_expected_count`
+  - `bucket_mass_ok`
+  - `bucket_mass_guardrail_applied`
+  - `drift_error`
+  - `breakpoints`
 
 Allowed `error_code` values:
 

--- a/python/docs/model_manager_diagnostics_snapshot.md
+++ b/python/docs/model_manager_diagnostics_snapshot.md
@@ -4,4 +4,11 @@ Canonical location:
 
 - `docs/inference/model_manager_diagnostics_contract.md`
 
+That document is the single source of truth for:
+
+- `diagnostics.ml_health` payload shape
+- strict-config visibility in diagnostics / health projection
+- drift result/error contract fields (`error_code`, `error_message`, `error`,
+  `resolution_mode`, reference metadata)
+
 This file remains as a pointer to avoid duplicated contracts drifting over time.

--- a/python/src/forecast/model_manager.py
+++ b/python/src/forecast/model_manager.py
@@ -8,6 +8,7 @@ Provides a singleton ModelManager that handles:
 
 import json
 import logging
+import math
 import os
 import pickle
 import time
@@ -124,6 +125,9 @@ class ModelManager:
         "strict_feature_schema",
         "strict_tuning_resume_validation",
         "strict_split_strategy_validation",
+    )
+    _ML_HEALTH_REQUIRED_SECTIONS = frozenset(
+        {"model", "benchmark", "drift", "feature_coverage", "config"}
     )
 
     def __new__(cls) -> "ModelManager":
@@ -500,11 +504,21 @@ class ModelManager:
         if isinstance(value, bool):
             return None
         if isinstance(value, int | float):
-            return float(value)
+            parsed = float(value)
+            return parsed if math.isfinite(parsed) else None
         try:
-            return float(value)
+            parsed = float(value)
+            return parsed if math.isfinite(parsed) else None
         except (TypeError, ValueError):
             return None
+
+    @staticmethod
+    def _coerce_reference_available(selected_run_id: Any) -> bool | None:
+        if selected_run_id is None:
+            return None
+        if isinstance(selected_run_id, list | tuple | set | dict):
+            return None
+        return bool(str(selected_run_id).strip())
 
     @staticmethod
     def _coerce_ratio_or_none(value: Any) -> float | None:
@@ -560,7 +574,9 @@ class ModelManager:
             if cached_result is not None:
                 computed_at = getattr(cached_result, "computed_at", None)
                 if computed_at is not None and hasattr(computed_at, "timestamp"):
-                    drift_last_computed_ts = float(computed_at.timestamp())
+                    drift_last_computed_ts = self._coerce_float_or_none(
+                        computed_at.timestamp()
+                    )
 
                 result_payload = getattr(cached_result, "result", {})
                 if isinstance(result_payload, dict):
@@ -574,10 +590,9 @@ class ModelManager:
                                 resolution.get("resolution_strategy")
                             )
                         selected_run_id = resolution.get("selected_run_id")
-                        if selected_run_id is not None:
-                            drift_reference_available = bool(
-                                str(selected_run_id).strip()
-                            )
+                        drift_reference_available = self._coerce_reference_available(
+                            selected_run_id
+                        )
 
                     error_code = result_payload.get("error_code")
                     if isinstance(error_code, str) and error_code.strip():
@@ -686,7 +701,11 @@ class ModelManager:
         """Get the current bounded ML health summary snapshot."""
         diagnostics = self.get_diagnostics()
         payload = diagnostics.get(DIAGNOSTIC_KEY_ML_HEALTH)
-        return payload if isinstance(payload, dict) else {}
+        if isinstance(payload, dict) and self._ML_HEALTH_REQUIRED_SECTIONS.issubset(
+            payload.keys()
+        ):
+            return payload
+        return self._build_ml_health_summary(diagnostics)
 
     @staticmethod
     def _effective_strict_config() -> dict[str, bool]:

--- a/python/src/training/detect_drift.py
+++ b/python/src/training/detect_drift.py
@@ -107,6 +107,11 @@ DRIFT_REFERENCE_MODEL_ALIAS = os.getenv("DRIFT_REFERENCE_MODEL_ALIAS", "").strip
 _DRIFT_STAGE_FALLBACK_WARNED = False
 _DRIFT_LATEST_FALLBACK_WARNED = False
 MAX_DRIFT_ERROR_MESSAGE_LENGTH = 200
+MAX_DRIFT_REFERENCE_VERSION_LENGTH = 64
+MAX_DRIFT_REFERENCE_RUN_ID_LENGTH = 128
+MAX_DRIFT_REFERENCE_ALIAS_LENGTH = 64
+MAX_DRIFT_BUCKETTYPE_LENGTH = 24
+MAX_DRIFT_BREAKPOINTS = 20
 _DEFAULT_DRIFT_ERROR_MESSAGES = {
     DriftErrorCode.NO_REFERENCE_DATA.value: "No reference data available",
     DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value: (
@@ -379,6 +384,71 @@ def _normalize_resolution_mode(raw_strategy: Any) -> str:
     return DriftResolutionMode.NONE.value
 
 
+def _bounded_metadata_text(value: Any, *, max_len: int) -> str | None:
+    if value is None:
+        return None
+    rendered = str(value).strip()
+    if not rendered:
+        return None
+    return rendered[:max_len]
+
+
+def _coerce_int_or_none(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_float_or_none(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+        if np.isfinite(parsed):
+            return parsed
+        return None
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_reference_resolution(raw_resolution: Any) -> dict[str, Any]:
+    source = raw_resolution if isinstance(raw_resolution, dict) else {}
+    requested_alias = _bounded_metadata_text(
+        source.get("requested_alias") or DRIFT_REFERENCE_MODEL_ALIAS,
+        max_len=MAX_DRIFT_REFERENCE_ALIAS_LENGTH,
+    )
+    normalized_mode = _normalize_resolution_mode(
+        source.get("resolution_mode") or source.get("resolution_strategy")
+    )
+    alias_candidate_count = _coerce_int_or_none(source.get("alias_candidate_count"))
+    if alias_candidate_count is None or alias_candidate_count < 0:
+        alias_candidate_count = 0
+
+    alias_ambiguous_raw = source.get("alias_ambiguous")
+    alias_ambiguous = (
+        bool(alias_ambiguous_raw) if alias_ambiguous_raw is not None else False
+    )
+
+    return {
+        "requested_alias": requested_alias,
+        "resolution_strategy": normalized_mode,
+        "resolution_mode": normalized_mode,
+        "alias_candidate_count": alias_candidate_count,
+        "alias_ambiguous": alias_ambiguous,
+        "selected_model_version": _bounded_metadata_text(
+            source.get("selected_model_version"),
+            max_len=MAX_DRIFT_REFERENCE_VERSION_LENGTH,
+        ),
+        "selected_run_id": _bounded_metadata_text(
+            source.get("selected_run_id"),
+            max_len=MAX_DRIFT_REFERENCE_RUN_ID_LENGTH,
+        ),
+    }
+
+
 def _bounded_error_message(message: Any) -> str:
     if message is None:
         return ""
@@ -392,6 +462,60 @@ def _bounded_error_code(code: Any) -> str | None:
     if not rendered:
         return None
     return rendered[:MAX_DRIFT_ERROR_CODE_LENGTH]
+
+
+def _normalize_bucketing_metadata(raw_bucketing: Any) -> dict[str, Any]:
+    source = raw_bucketing if isinstance(raw_bucketing, dict) else {}
+    breakpoints = None
+    raw_breakpoints = source.get("breakpoints")
+    if isinstance(raw_breakpoints, list | tuple):
+        normalized_breakpoints = []
+        for point in list(raw_breakpoints)[:MAX_DRIFT_BREAKPOINTS]:
+            parsed = _coerce_float_or_none(point)
+            if parsed is not None:
+                normalized_breakpoints.append(parsed)
+        breakpoints = normalized_breakpoints
+
+    bucket_mass_ok_raw = source.get("bucket_mass_ok")
+    bucket_mass_guardrail_raw = source.get("bucket_mass_guardrail_applied")
+    drift_error = _bounded_error_code(source.get("drift_error"))
+    if drift_error is None:
+        drift_error = _normalize_error_code(source.get("drift_error"))
+
+    return {
+        "buckettype_requested": _bounded_metadata_text(
+            source.get("buckettype_requested"),
+            max_len=MAX_DRIFT_BUCKETTYPE_LENGTH,
+        ),
+        "buckettype_used": _bounded_metadata_text(
+            source.get("buckettype_used"),
+            max_len=MAX_DRIFT_BUCKETTYPE_LENGTH,
+        ),
+        "buckets_requested": _coerce_int_or_none(source.get("buckets_requested")),
+        "buckets_used": _coerce_int_or_none(source.get("buckets_used")),
+        "bucketing_fallback_reason": _bounded_metadata_text(
+            source.get("bucketing_fallback_reason"),
+            max_len=MAX_DRIFT_ERROR_CODE_LENGTH,
+        ),
+        "reference_sample_size": _coerce_int_or_none(
+            source.get("reference_sample_size")
+        ),
+        "nonempty_buckets": _coerce_int_or_none(source.get("nonempty_buckets")),
+        "nonempty_buckets_ratio": _coerce_float_or_none(
+            source.get("nonempty_buckets_ratio")
+        ),
+        "min_expected_count": _coerce_float_or_none(source.get("min_expected_count")),
+        "bucket_mass_ok": (
+            bool(bucket_mass_ok_raw) if bucket_mass_ok_raw is not None else None
+        ),
+        "bucket_mass_guardrail_applied": (
+            bool(bucket_mass_guardrail_raw)
+            if bucket_mass_guardrail_raw is not None
+            else None
+        ),
+        "drift_error": drift_error,
+        "breakpoints": breakpoints,
+    }
 
 
 def _set_canonical_error(
@@ -444,15 +568,19 @@ def _infer_error_code_from_message(message: Any) -> str | None:
 
 def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
     """Normalize additive drift error contract fields for stability."""
+    reference_resolution = _normalize_reference_resolution(
+        results.get("reference_resolution")
+    )
     raw_resolution_mode = results.get("resolution_mode")
     normalized_resolution_mode = _normalize_resolution_mode(raw_resolution_mode)
     if normalized_resolution_mode == DriftResolutionMode.NONE.value:
-        reference_resolution = results.get("reference_resolution")
-        if isinstance(reference_resolution, dict):
-            normalized_resolution_mode = _normalize_resolution_mode(
-                reference_resolution.get("resolution_mode")
-                or reference_resolution.get("resolution_strategy")
-            )
+        normalized_resolution_mode = _normalize_resolution_mode(
+            reference_resolution.get("resolution_mode")
+            or reference_resolution.get("resolution_strategy")
+        )
+    reference_resolution["resolution_strategy"] = normalized_resolution_mode
+    reference_resolution["resolution_mode"] = normalized_resolution_mode
+    results["reference_resolution"] = reference_resolution
     results["resolution_mode"] = normalized_resolution_mode
 
     error_code = _normalize_error_code(results.get("error_code"))
@@ -476,13 +604,24 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
             results["error"] = None
     else:
         results["error_message"] = None
+        results["error"] = None
 
     results["error_code"] = error_code
 
-    reference_model_version = results.get("reference_model_version")
-    if reference_model_version is not None:
-        text = str(reference_model_version).strip()
-        results["reference_model_version"] = text[:64] if text else None
+    normalized_drift_error = _normalize_error_code(results.get("drift_error"))
+    if normalized_drift_error is None:
+        normalized_drift_error = _bounded_error_code(results.get("drift_error"))
+    results["drift_error"] = error_code or normalized_drift_error
+
+    reference_model_version = _bounded_metadata_text(
+        results.get("reference_model_version"),
+        max_len=MAX_DRIFT_REFERENCE_VERSION_LENGTH,
+    )
+    if reference_model_version is None:
+        reference_model_version = reference_resolution.get("selected_model_version")
+    results["reference_model_version"] = reference_model_version
+    if reference_resolution.get("selected_model_version") is None:
+        reference_resolution["selected_model_version"] = reference_model_version
 
     return results
 
@@ -579,6 +718,7 @@ def detect_drift(
     threshold: float = PSI_THRESHOLD_CRITICAL,
 ) -> dict[str, Any]:
     """Run drift detection."""
+    initial_reference_resolution = _normalize_reference_resolution({})
     results = {
         "timestamp": datetime.now(UTC).isoformat(),
         "hours_analyzed": hours,
@@ -591,28 +731,28 @@ def detect_drift(
         "drift_error": None,
         "error_code": None,
         "error_message": None,
+        "error": None,
         "resolution_mode": DriftResolutionMode.NONE.value,
         "alerts": [],
-        "reference_resolution": {},
+        "reference_resolution": initial_reference_resolution,
         "reference_model_version": None,
     }
 
     reference_result = get_reference_data(include_metadata=True)
-    reference_resolution: dict[str, Any] = {}
+    reference_resolution: dict[str, Any] = initial_reference_resolution
     if isinstance(reference_result, tuple):
-        df_reference, reference_resolution = reference_result
+        df_reference, raw_reference_resolution = reference_result
+        reference_resolution = _normalize_reference_resolution(raw_reference_resolution)
     else:
         df_reference = reference_result
 
-    if reference_resolution:
-        results["reference_resolution"] = reference_resolution
-        selected_version = reference_resolution.get("selected_model_version")
-        if selected_version is not None:
-            results["reference_model_version"] = str(selected_version)[:64]
+    results["reference_resolution"] = reference_resolution
+    selected_version = reference_resolution.get("selected_model_version")
+    if selected_version is not None:
+        results["reference_model_version"] = selected_version
     results["resolution_mode"] = _normalize_resolution_mode(
-        reference_resolution.get("resolution_strategy")
-        if isinstance(reference_resolution, dict)
-        else None
+        reference_resolution.get("resolution_mode")
+        or reference_resolution.get("resolution_strategy")
     )
 
     if df_reference is None or len(df_reference) == 0:
@@ -656,9 +796,10 @@ def detect_drift(
         expected = df_reference[feature].values.astype(float)
         actual = df_current[feature].values.astype(float)
 
-        psi, bucketing = calculate_psi(
+        psi, bucketing_raw = calculate_psi(
             expected, actual, buckettype="quantiles", buckets=10
         )
+        bucketing = _normalize_bucketing_metadata(bucketing_raw)
         drift_error = (
             bucketing.get("drift_error") if isinstance(bucketing, dict) else None
         )
@@ -715,6 +856,7 @@ def detect_drift(
         results["features"][feature] = {
             "psi": round(psi, 4),
             "status": status,
+            "drift_error": None,
             "bucketing": bucketing,
         }
 

--- a/python/tests/test_contract_compatibility_guards.py
+++ b/python/tests/test_contract_compatibility_guards.py
@@ -1,0 +1,305 @@
+"""Compatibility guardrails for ML health + drift contract payloads."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from forecast.model_manager import ModelManager
+from training.detect_drift import (
+    MAX_DRIFT_ERROR_MESSAGE_LENGTH,
+    MIN_REFERENCE_SAMPLES,
+    detect_drift,
+)
+from training.reason_codes import DriftErrorCode, DriftResolutionMode
+
+ML_HEALTH_KEYS = {
+    "model",
+    "benchmark",
+    "drift",
+    "feature_coverage",
+    "config",
+    "state",
+    "active_model_version",
+    "last_reload_status",
+    "last_reload_ts",
+    "schema_mismatch_detected",
+    "benchmark_status",
+    "feature_coverage_status",
+    "feature_coverage_last_seen_ts",
+    "drift_reference_available",
+    "drift_resolution_mode",
+    "drift_last_computed_ts",
+    "drift_last_error_code",
+}
+ML_HEALTH_MODEL_KEYS = {
+    "state",
+    "active_model_version",
+    "last_reload_status",
+    "last_reload_ts",
+    "schema_mismatch_detected",
+}
+ML_HEALTH_BENCHMARK_KEYS = {"enabled", "last_status", "last_run_ts"}
+ML_HEALTH_DRIFT_KEYS = {"reference_resolution_mode", "last_error_code"}
+ML_HEALTH_FEATURE_COVERAGE_KEYS = {"last_ratio", "below_threshold"}
+ML_HEALTH_CONFIG_KEYS = {
+    "strict_feature_schema",
+    "strict_tuning_resume_validation",
+    "strict_split_strategy_validation",
+}
+
+DRIFT_RESULT_KEYS = {
+    "timestamp",
+    "hours_analyzed",
+    "threshold",
+    "reference_size",
+    "live_size",
+    "features",
+    "drift_detected",
+    "drifted_features",
+    "drift_error",
+    "error_code",
+    "error_message",
+    "error",
+    "resolution_mode",
+    "alerts",
+    "reference_resolution",
+    "reference_model_version",
+}
+REFERENCE_RESOLUTION_KEYS = {
+    "requested_alias",
+    "resolution_strategy",
+    "resolution_mode",
+    "alias_candidate_count",
+    "alias_ambiguous",
+    "selected_model_version",
+    "selected_run_id",
+}
+DRIFT_FEATURE_KEYS = {"psi", "status", "drift_error", "bucketing"}
+BUCKETING_KEYS = {
+    "buckettype_requested",
+    "buckettype_used",
+    "buckets_requested",
+    "buckets_used",
+    "bucketing_fallback_reason",
+    "reference_sample_size",
+    "nonempty_buckets",
+    "nonempty_buckets_ratio",
+    "min_expected_count",
+    "bucket_mass_ok",
+    "bucket_mass_guardrail_applied",
+    "drift_error",
+    "breakpoints",
+}
+
+
+def _fresh_manager() -> ModelManager:
+    ModelManager._instance = None
+    return ModelManager()
+
+
+def _stable_frame(size: int = 1000) -> pd.DataFrame:
+    base = np.arange(size, dtype=float)
+    return pd.DataFrame(
+        {
+            "velocity_24h": base,
+            "amount_to_avg_ratio_30d": base * 0.5,
+            "balance_volatility_z_score": base - 250.0,
+        }
+    )
+
+
+def test_ml_health_contract_guard_shape_types_and_bounds():
+    manager = _fresh_manager()
+    manager.update_feature_coverage_warning(
+        active=True, coverage_ratio=0.42, observed_ts=100.5
+    )
+    mock_cache = SimpleNamespace(
+        _cache=SimpleNamespace(
+            computed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            result={
+                "resolution_mode": "stage",
+                "error_code": "no_reference_data",
+                "reference_resolution": {"selected_run_id": "run-123"},
+            },
+        )
+    )
+
+    with patch("forecast.drift_cache.get_drift_cache", return_value=mock_cache):
+        health = manager.get_diagnostics()["ml_health"]
+
+    assert set(health.keys()) == ML_HEALTH_KEYS
+    assert set(health["model"].keys()) == ML_HEALTH_MODEL_KEYS
+    assert set(health["benchmark"].keys()) == ML_HEALTH_BENCHMARK_KEYS
+    assert set(health["drift"].keys()) == ML_HEALTH_DRIFT_KEYS
+    assert set(health["feature_coverage"].keys()) == ML_HEALTH_FEATURE_COVERAGE_KEYS
+    assert set(health["config"].keys()) == ML_HEALTH_CONFIG_KEYS
+
+    assert isinstance(health["state"], str)
+    assert isinstance(health["active_model_version"], str)
+    assert isinstance(health["last_reload_status"], str)
+    assert len(health["active_model_version"]) <= 64
+    assert len(health["last_reload_status"]) <= 32
+    assert health["last_reload_ts"] is None or isinstance(
+        health["last_reload_ts"], float
+    )
+    assert isinstance(health["schema_mismatch_detected"], bool)
+    assert isinstance(health["benchmark"]["enabled"], bool)
+    assert health["benchmark"]["last_status"] is None or isinstance(
+        health["benchmark"]["last_status"], str
+    )
+    assert health["benchmark"]["last_run_ts"] is None or isinstance(
+        health["benchmark"]["last_run_ts"], float
+    )
+    assert health["drift"]["last_error_code"] is None or isinstance(
+        health["drift"]["last_error_code"], str
+    )
+    assert health["feature_coverage"]["last_ratio"] is None or isinstance(
+        health["feature_coverage"]["last_ratio"], float
+    )
+    assert isinstance(health["feature_coverage"]["below_threshold"], bool)
+    assert all(isinstance(value, bool) for value in health["config"].values())
+    assert health["drift_resolution_mode"] in {"alias", "stage", "latest", "none"}
+    assert health["drift"]["reference_resolution_mode"] in {
+        "alias",
+        "stage",
+        "latest",
+        "none",
+    }
+    assert (
+        health["drift_last_error_code"] is None
+        or len(health["drift_last_error_code"]) <= 64
+    )
+    assert all(
+        not isinstance(value, list | tuple | set)
+        for key, value in health.items()
+        if key not in {"model", "benchmark", "drift", "feature_coverage", "config"}
+    )
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_code", "expected_mode", "expected_version"),
+    [
+        (
+            "success",
+            None,
+            DriftResolutionMode.ALIAS.value,
+            "9",
+        ),
+        (
+            "no_reference",
+            DriftErrorCode.NO_REFERENCE_DATA.value,
+            DriftResolutionMode.NONE.value,
+            None,
+        ),
+        (
+            "insufficient_reference",
+            DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value,
+            DriftResolutionMode.NONE.value,
+            None,
+        ),
+        (
+            "suppressed_bucket_mass",
+            DriftErrorCode.INSUFFICIENT_BUCKET_MASS.value,
+            DriftResolutionMode.NONE.value,
+            None,
+        ),
+    ],
+)
+@patch("training.detect_drift.get_reference_data")
+@patch("training.detect_drift.get_live_data")
+def test_drift_contract_guard_shape_across_modes(
+    mock_live,
+    mock_ref,
+    scenario,
+    expected_code,
+    expected_mode,
+    expected_version,
+):
+    stable_df = _stable_frame()
+    if scenario == "success":
+        mock_ref.return_value = (
+            stable_df,
+            {
+                "resolution_strategy": "alias",
+                "selected_model_version": "9",
+                "selected_run_id": "run-v9",
+            },
+        )
+        mock_live.return_value = stable_df.copy()
+    elif scenario == "no_reference":
+        mock_ref.return_value = None
+        mock_live.return_value = pd.DataFrame()
+    elif scenario == "insufficient_reference":
+        mock_ref.return_value = _stable_frame(size=50)
+        mock_live.return_value = pd.DataFrame()
+    elif scenario == "suppressed_bucket_mass":
+        sample_size = MIN_REFERENCE_SAMPLES + 20
+        sparse_reference = np.array([0.0] * (sample_size - 10) + [1.0] * 10)
+        sparse_live = np.array([0.0] * (sample_size - 30) + [8.0] * 30)
+        mock_ref.return_value = pd.DataFrame(
+            {
+                "velocity_24h": sparse_reference,
+                "amount_to_avg_ratio_30d": sparse_reference,
+                "balance_volatility_z_score": sparse_reference,
+            }
+        )
+        mock_live.return_value = pd.DataFrame(
+            {
+                "velocity_24h": sparse_live,
+                "amount_to_avg_ratio_30d": sparse_live,
+                "balance_volatility_z_score": sparse_live,
+            }
+        )
+    else:
+        raise AssertionError(f"Unsupported scenario: {scenario}")
+
+    result = detect_drift()
+
+    assert set(result.keys()) == DRIFT_RESULT_KEYS
+    assert result["error_code"] == expected_code
+    assert result["resolution_mode"] == expected_mode
+    assert result["reference_model_version"] == expected_version
+    assert isinstance(result["timestamp"], str)
+    assert (
+        result["error_message"] is None
+        or len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
+    )
+    assert set(result["reference_resolution"].keys()) == REFERENCE_RESOLUTION_KEYS
+    assert (
+        result["reference_resolution"]["resolution_mode"] == result["resolution_mode"]
+    )
+    assert (
+        result["reference_resolution"]["resolution_strategy"]
+        == result["resolution_mode"]
+    )
+    assert isinstance(result["reference_resolution"]["alias_candidate_count"], int)
+    assert isinstance(result["reference_resolution"]["alias_ambiguous"], bool)
+    assert (
+        result["reference_resolution"]["selected_model_version"] is None
+        or len(result["reference_resolution"]["selected_model_version"]) <= 64
+    )
+    assert (
+        result["reference_resolution"]["selected_run_id"] is None
+        or len(result["reference_resolution"]["selected_run_id"]) <= 128
+    )
+    if result["error_code"] is None:
+        assert result["error"] is None
+    else:
+        assert result["error"] == result["error_message"]
+
+    for feature_result in result["features"].values():
+        assert set(feature_result.keys()) == DRIFT_FEATURE_KEYS
+        assert set(feature_result["bucketing"].keys()) == BUCKETING_KEYS
+        assert feature_result["status"] in {"OK", "WARNING", "CRITICAL"}
+        assert len(feature_result["status"]) <= 16
+        assert (
+            feature_result["drift_error"] is None
+            or len(feature_result["drift_error"]) <= 64
+        )
+        breakpoints = feature_result["bucketing"]["breakpoints"]
+        if isinstance(breakpoints, list):
+            assert len(breakpoints) <= 20

--- a/python/tests/test_detect_drift.py
+++ b/python/tests/test_detect_drift.py
@@ -19,6 +19,49 @@ from training.detect_drift import (
 )
 from training.reason_codes import DriftErrorCode, DriftResolutionMode
 
+DRIFT_RESULT_CORE_KEYS = {
+    "timestamp",
+    "hours_analyzed",
+    "threshold",
+    "reference_size",
+    "live_size",
+    "features",
+    "drift_detected",
+    "drifted_features",
+    "drift_error",
+    "error_code",
+    "error_message",
+    "error",
+    "resolution_mode",
+    "alerts",
+    "reference_resolution",
+    "reference_model_version",
+}
+REFERENCE_RESOLUTION_KEYS = {
+    "requested_alias",
+    "resolution_strategy",
+    "resolution_mode",
+    "alias_candidate_count",
+    "alias_ambiguous",
+    "selected_model_version",
+    "selected_run_id",
+}
+BUCKETING_METADATA_KEYS = {
+    "buckettype_requested",
+    "buckettype_used",
+    "buckets_requested",
+    "buckets_used",
+    "bucketing_fallback_reason",
+    "reference_sample_size",
+    "nonempty_buckets",
+    "nonempty_buckets_ratio",
+    "min_expected_count",
+    "bucket_mass_ok",
+    "bucket_mass_guardrail_applied",
+    "drift_error",
+    "breakpoints",
+}
+
 
 class TestCalculatePsi:
     """Tests for calculate_psi function."""
@@ -378,8 +421,11 @@ class TestReferenceResolution:
 
         result = detect_drift()
 
+        assert set(result["reference_resolution"].keys()) == REFERENCE_RESOLUTION_KEYS
+        assert result["reference_resolution"]["resolution_mode"] == "alias"
         assert result["reference_resolution"]["resolution_strategy"] == "alias"
         assert result["reference_resolution"]["selected_model_version"] == "9"
+        assert result["reference_resolution"]["selected_run_id"] == "run-v9"
 
 
 class TestDetectDrift:
@@ -774,6 +820,7 @@ class TestDetectDrift:
 
         assert result["error_code"] is None
         assert result["error_message"] is None
+        assert result["error"] is None
         assert result["resolution_mode"] == DriftResolutionMode.ALIAS.value
         assert result["reference_model_version"] == "9"
 
@@ -802,6 +849,7 @@ class TestDetectDrift:
                 "live_payload": pd.DataFrame(),
                 "expected_code": DriftErrorCode.NO_REFERENCE_DATA.value,
                 "expected_mode": DriftResolutionMode.NONE.value,
+                "expected_reference_version": None,
             },
             {
                 "name": "insufficient_reference_samples",
@@ -815,6 +863,7 @@ class TestDetectDrift:
                 "live_payload": pd.DataFrame(),
                 "expected_code": DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value,
                 "expected_mode": DriftResolutionMode.NONE.value,
+                "expected_reference_version": None,
             },
             {
                 "name": "insufficient_bucket_mass",
@@ -834,6 +883,7 @@ class TestDetectDrift:
                 ),
                 "expected_code": DriftErrorCode.INSUFFICIENT_BUCKET_MASS.value,
                 "expected_mode": DriftResolutionMode.NONE.value,
+                "expected_reference_version": None,
             },
             {
                 "name": "success",
@@ -848,6 +898,7 @@ class TestDetectDrift:
                 "live_payload": stable_df.copy(),
                 "expected_code": None,
                 "expected_mode": DriftResolutionMode.ALIAS.value,
+                "expected_reference_version": "9",
             },
             {
                 "name": "success_stage_mode_from_canonical_reference_metadata",
@@ -862,6 +913,7 @@ class TestDetectDrift:
                 "live_payload": stable_df.copy(),
                 "expected_code": None,
                 "expected_mode": DriftResolutionMode.STAGE.value,
+                "expected_reference_version": "7",
             },
         ]
 
@@ -870,6 +922,7 @@ class TestDetectDrift:
             mock_live.return_value = scenario["live_payload"]
             result = detect_drift()
 
+            assert set(result.keys()) == DRIFT_RESULT_CORE_KEYS, scenario["name"]
             assert "error_code" in result, scenario["name"]
             assert "error_message" in result, scenario["name"]
             assert "resolution_mode" in result, scenario["name"]
@@ -877,10 +930,50 @@ class TestDetectDrift:
             assert result["resolution_mode"] == scenario["expected_mode"], scenario[
                 "name"
             ]
+            assert (
+                result["reference_model_version"]
+                == scenario["expected_reference_version"]
+            ), scenario["name"]
+            assert (
+                set(result["reference_resolution"].keys()) == REFERENCE_RESOLUTION_KEYS
+            ), scenario["name"]
+            assert (
+                result["reference_resolution"]["resolution_mode"]
+                == result["resolution_mode"]
+            ), scenario["name"]
+            assert (
+                result["reference_resolution"]["resolution_strategy"]
+                == result["resolution_mode"]
+            ), scenario["name"]
+            assert isinstance(
+                result["reference_resolution"]["alias_candidate_count"], int
+            ), scenario["name"]
+            assert isinstance(
+                result["reference_resolution"]["alias_ambiguous"], bool
+            ), scenario["name"]
+            if result["error_code"] is None:
+                assert result["error"] is None, scenario["name"]
+            else:
+                assert result["error"] == result["error_message"], scenario["name"]
             if result["error_message"] is not None:
                 assert len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH, (
                     scenario["name"]
                 )
+            for feature_name, feature_result in result["features"].items():
+                assert feature_name in {
+                    "velocity_24h",
+                    "amount_to_avg_ratio_30d",
+                    "balance_volatility_z_score",
+                }, scenario["name"]
+                assert set(feature_result.keys()) == {
+                    "psi",
+                    "status",
+                    "drift_error",
+                    "bucketing",
+                }, scenario["name"]
+                assert (
+                    set(feature_result["bucketing"].keys()) == BUCKETING_METADATA_KEYS
+                ), scenario["name"]
 
     def test_drift_error_contract_maps_legacy_fields(self):
         legacy = {

--- a/python/tests/test_model_manager_defaults.py
+++ b/python/tests/test_model_manager_defaults.py
@@ -203,6 +203,94 @@ def test_ml_health_summary_is_stable_and_bounded():
     )
 
 
+def test_ml_health_summary_uses_null_for_unset_optional_fields():
+    manager = _fresh_manager()
+    mock_cache = SimpleNamespace(_cache=None)
+
+    with patch("forecast.drift_cache.get_drift_cache", return_value=mock_cache):
+        health = manager.get_ml_health_summary()
+
+    assert health["model"]["last_reload_ts"] is None
+    assert health["benchmark"]["last_status"] is None
+    assert health["benchmark"]["last_run_ts"] is None
+    assert health["feature_coverage"]["last_ratio"] is None
+    assert health["feature_coverage_last_seen_ts"] is None
+    assert health["drift"]["last_error_code"] is None
+    assert health["drift_reference_available"] is None
+    assert health["drift_last_computed_ts"] is None
+    assert health["drift_last_error_code"] is None
+
+
+def test_ml_health_summary_rebuilds_canonical_shape_when_payload_incomplete():
+    manager = _fresh_manager()
+    incomplete = {
+        "state": "ready",
+        "active_model_version": "v" * 200,
+        "last_reload_status": "status-" * 20,
+        "last_reload_ts": "nan",
+        "schema_mismatch_detected": False,
+        "benchmark_last_status": "benchmark-status-" * 20,
+        "benchmark_last_run_ts": "inf",
+        "feature_coverage_warning_active": True,
+        "feature_coverage_last_ratio": 1.7,
+        "feature_coverage_warning_last_seen_ts": "not-a-float",
+        "config": {
+            "strict_feature_schema": "yes",
+            "strict_tuning_resume_validation": "0",
+            "strict_split_strategy_validation": 1,
+            "unexpected_key": True,
+        },
+        "ml_health": {"model": [], "unexpected_nested": {"a": "b"}},
+    }
+
+    with (
+        patch.object(manager, "get_diagnostics", return_value=incomplete),
+        patch(
+            "forecast.drift_cache.get_drift_cache",
+            return_value=SimpleNamespace(_cache=None),
+        ),
+    ):
+        health = manager.get_ml_health_summary()
+
+    assert set(health["config"].keys()) == {
+        "strict_feature_schema",
+        "strict_tuning_resume_validation",
+        "strict_split_strategy_validation",
+    }
+    assert health["config"] == {
+        "strict_feature_schema": True,
+        "strict_tuning_resume_validation": False,
+        "strict_split_strategy_validation": True,
+    }
+    assert set(health["model"].keys()) == {
+        "state",
+        "active_model_version",
+        "last_reload_status",
+        "last_reload_ts",
+        "schema_mismatch_detected",
+    }
+    assert set(health["benchmark"].keys()) == {"enabled", "last_status", "last_run_ts"}
+    assert set(health["drift"].keys()) == {
+        "reference_resolution_mode",
+        "last_error_code",
+    }
+    assert set(health["feature_coverage"].keys()) == {"last_ratio", "below_threshold"}
+    assert len(health["active_model_version"]) <= 64
+    assert len(health["last_reload_status"]) <= 32
+    assert health["last_reload_ts"] is None
+    assert health["benchmark"]["last_run_ts"] is None
+    assert health["feature_coverage_last_seen_ts"] is None
+    assert health["benchmark"]["last_status"] is None or (
+        len(health["benchmark"]["last_status"]) <= 32
+    )
+    assert health["feature_coverage"]["last_ratio"] == 1.0
+    assert all(
+        not isinstance(value, list | tuple | set)
+        for key, value in health.items()
+        if key not in {"model", "benchmark", "drift", "feature_coverage", "config"}
+    )
+
+
 def test_ml_health_feature_coverage_ratio_tracks_last_observation():
     manager = _fresh_manager()
     manager.update_feature_coverage_warning(

--- a/python/tests/test_obs_payload_shapes_golden.py
+++ b/python/tests/test_obs_payload_shapes_golden.py
@@ -144,6 +144,7 @@ def test_detect_drift_payload_golden_shape_and_bounds(mock_live, mock_ref):
         "drift_error",
         "error_code",
         "error_message",
+        "error",
         "resolution_mode",
         "alerts",
         "reference_resolution",
@@ -157,15 +158,24 @@ def test_detect_drift_payload_golden_shape_and_bounds(mock_live, mock_ref):
     assert result["error_message"] is None or (
         len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
     )
+    assert result["error"] is None
     assert result["reference_model_version"] is None or (
         len(result["reference_model_version"]) <= 64
     )
 
     for feature_name, feature_result in result["features"].items():
         assert feature_name in MONITORED_FEATURES
-        assert set(feature_result.keys()) == {"psi", "status", "bucketing"}
+        assert set(feature_result.keys()) == {
+            "psi",
+            "status",
+            "drift_error",
+            "bucketing",
+        }
         assert feature_result["status"] in {"OK", "WARNING", "CRITICAL"}
         assert len(feature_result["status"]) <= 16
+        assert feature_result["drift_error"] is None or isinstance(
+            feature_result["drift_error"], str
+        )
         assert isinstance(feature_result["bucketing"], dict)
         breakpoints = feature_result["bucketing"].get("breakpoints")
         if isinstance(breakpoints, list):

--- a/python/tests/test_operability_contract_shapes.py
+++ b/python/tests/test_operability_contract_shapes.py
@@ -157,6 +157,7 @@ def test_drift_contract_shape_and_bounds(mock_live, mock_ref):
         "drift_error",
         "error_code",
         "error_message",
+        "error",
         "resolution_mode",
         "alerts",
         "reference_resolution",
@@ -171,11 +172,20 @@ def test_drift_contract_shape_and_bounds(mock_live, mock_ref):
         result["error_message"] is None
         or len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
     )
+    assert result["error"] is None
 
     for feature_name, feature_result in result["features"].items():
         assert feature_name in MONITORED_FEATURES
-        assert set(feature_result.keys()) == {"psi", "status", "bucketing"}
+        assert set(feature_result.keys()) == {
+            "psi",
+            "status",
+            "drift_error",
+            "bucketing",
+        }
         assert feature_result["status"] in {"OK", "WARNING", "CRITICAL"}
+        assert feature_result["drift_error"] is None or isinstance(
+            feature_result["drift_error"], str
+        )
         breakpoints = feature_result["bucketing"].get("breakpoints")
         if isinstance(breakpoints, list):
             assert len(breakpoints) <= 20


### PR DESCRIPTION
#### Summary

* normalize ML health payload semantics
* align drift result contract across result modes
* add compatibility guard tests
* consolidate ML operability docs

#### Compatibility

* additive / non-breaking only
* no new dependencies
* no API removals

#### Test plan

...........................................sssssssssssssssssssssssssssss [ 16%]
ssssssssssssssssss...................................................... [ 33%]
........................................................................ [ 50%]
................ss...................................................... [ 67%]
........................................................................ [ 84%]
................................s...................................     [100%]
=============================== warnings summary ===============================
python/tests/model/test_calibration_guards.py::TestCalibrationGuards::test_calibration_skipped_insufficient_samples
python/tests/model/test_calibration_guards.py::TestCalibrationGuards::test_calibration_skipped_insufficient_positives
python/tests/model/test_calibration_guards.py::TestCalibrationGuards::test_calibration_skipped_insufficient_negatives
python/tests/model/test_calibration_guards.py::TestCalibrationGuards::test_calibration_success_when_thresholds_met
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/training.py:199: UserWarning: [02:00:26] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    bst.update(dtrain, iteration=i, fobj=obj)

python/tests/model/test_calibration_guards.py: 4 warnings
python/tests/model/test_schema_hash.py: 1 warning
python/tests/test_hyperparameters.py: 4 warnings
python/tests/test_obs_training_identity.py: 1 warning
python/tests/test_train_feature_columns.py: 3 warnings
python/tests/test_train_metrics.py: 6 warnings
python/tests/test_tuning.py: 1 warning
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/mlflow/types/utils.py:452: UserWarning: Hint: Inferred schema contains integer column(s). Integer columns in Python cannot represent missing values. If your input data contains missing values at inference time, it will be encoded as floats and will cause a schema enforcement error. The best way to avoid this problem is to infer the model schema based on a realistic data sample (training dataset) that includes missing values. Alternatively, you can declare integer columns as doubles (float64) whenever these columns may have missing values. See `Handling Integers With Missing Values <https://www.mlflow.org/docs/latest/models.html#handling-integers-with-missing-values>`_ for more details.
    warnings.warn(

python/tests/test_hyperparameters.py::TestHyperparamsLoggedToMlflow::test_hyperparams_logged_to_mlflow
python/tests/test_hyperparameters.py::TestDefaultHyperparamsUnchanged::test_default_hyperparams_unchanged
python/tests/test_train_feature_columns.py::TestTrainModelWithFeatureColumns::test_train_model_logs_feature_columns_param
python/tests/test_train_feature_columns.py::TestTrainModelWithFeatureColumns::test_train_model_logs_feature_columns_artifact
python/tests/test_train_feature_columns.py::TestTrainModelWithFeatureColumns::test_train_model_uses_default_columns_when_none_provided
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/training.py:199: UserWarning: [02:00:28] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    bst.update(dtrain, iteration=i, fobj=obj)

python/tests/test_hyperparameters.py::TestEarlyStopping::test_early_stopping_logs_best_iteration
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/callback.py:386: UserWarning: [02:00:28] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    self.starting_round = model.num_boosted_rounds()

python/tests/test_train_metrics.py: 17 warnings
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/training.py:199: UserWarning: [02:00:29] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    bst.update(dtrain, iteration=i, fobj=obj)

python/tests/test_tuning.py::TestTuningStudy::test_disabled_tuning_skipped
python/tests/test_tuning.py::TestSelectedTrialOverride::test_selected_trial_overrides_best
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/training.py:199: UserWarning: [02:00:30] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    bst.update(dtrain, iteration=i, fobj=obj)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
______________ coverage: platform darwin, python 3.12.12-final-0 _______________

Name                                          Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------------
python/src/features/registry.py                  21      2      2      1    87%   65, 76
python/src/features/store.py                     81     59     14      0    23%   21, 26, 33, 42-51, 64-76, 79-81, 85-113, 119-155, 160
python/src/forecast/drift_cache.py               48      5     10      3    86%   30-33, 73, 79
python/src/forecast/model_manager.py            826    137    286     52    80%   85-90, 137->140, 192, 194, 197-198, 268->exit, 271-272, 287, 289->280, 292->300, 296->300, 301-305, 325-326, 385, 423->425, 428, 436->438, 441, 454-469, 480-482, 490, 497, 505, 518, 520, 540->542, 554, 576->581, 582->608, 587->597, 600-606, 744, 850-859, 870-878, 1001-1002, 1026, 1032, 1053->1077, 1054->1053, 1062-1063, 1071, 1075-1076, 1087->1086, 1094, 1097-1098, 1109->1108, 1122-1123, 1138->1153, 1139->1138, 1151-1152, 1166->1180, 1167->1166, 1174, 1178-1179, 1185-1190, 1198-1200, 1206, 1210, 1216->1223, 1219-1222, 1255, 1344->1343, 1354-1355, 1380-1414, 1428->1427, 1430-1432, 1453-1457, 1479-1481, 1497-1525, 1540, 1554, 1557, 1603-1606
python/src/forecast/service.py                  110     22     22      4    80%   28, 38, 81-83, 87->90, 107-109, 116-117, 155-157, 196-216
python/src/forecast/services.py                 224     52     68      9    76%   42-46, 59-61, 172-173, 315->321, 356-360, 369-376, 420-459, 471-480, 507, 511-512, 516-517, 521-522, 526-527, 548-550
python/src/inference/__init__.py                  5      1      2      1    71%   9
python/src/inference/config.py                   48     27     14      0    34%   26-30, 48-54, 58-61, 65-76
python/src/inference/logging.py                   3      3      0      0     0%   3-7
python/src/inference/server.py                   34     34      6      0     0%   3-64
python/src/inference/service.py                  54     15     10      3    72%   34, 42, 64-65, 71-74, 83-84, 96-97, 103-114
python/src/logging_util.py                       13     13      2      0     0%   3-72
python/src/main.py                               47     47      8      0     0%   3-133
python/src/model/evaluate.py                    140      5     20      3    95%   152, 306->exit, 425-429
python/src/model/loader.py                       98      3     34      2    96%   133->139, 139->144, 235-238
python/src/model/split_strategies.py             75      7     12      4    87%   35, 50-51, 79-80, 118, 126
python/src/model/train.py                       483     47    136     24    88%   54-56, 100-101, 105->114, 109-111, 121, 123, 128, 146-147, 278-283, 305-307, 335, 362->368, 374, 456, 458, 469-470, 472->475, 533->633, 601->605, 800, 812->827, 823, 834->856, 846->856, 852, 875, 974-982, 987-994
python/src/model/tuning.py                      310     59    132     30    77%   76-79, 85, 88, 91-92, 95, 100-101, 116-120, 128-135, 158, 169, 191->194, 358-359, 362->368, 377-378, 384, 386->exit, 397->399, 400-418, 469-474, 484-485, 487->493, 490-491, 514, 536->602, 543->551, 555->602, 596, 599-600, 603, 605, 631, 649->661, 652-660, 672, 675->678, 680, 681->664, 689->730, 727-728
python/src/training/audit.py                     90      3     20      2    95%   38->40, 63, 89-90
python/src/training/config.py                    12      1      0      0    92%   19
python/src/training/crud_client.py              222     58     52     12    72%   52-58, 65->70, 117-118, 126-127, 147-158, 166-171, 176-177, 185-188, 227, 231-232, 242-243, 252-253, 262-263, 280-281, 294-298, 308-311, 324->326, 327, 400, 402, 408-409, 425, 434-439, 446-447, 454, 467, 469, 494-495, 500-501, 513->515, 528-529
python/src/training/detect_drift.py             415     71    154     18    80%   86-92, 184, 263-264, 272, 274, 277-278, 365->373, 401-402, 407, 412-414, 454, 463, 471->479, 475->473, 541, 547-549, 555-566, 603-604, 650, 674-680, 685-713, 871-886, 890
python/src/training/gateway_client.py            19     13      4      0    26%   12-29, 35
python/src/training/gateway_grpc_client.py       76     57     16      0    21%   13-17, 26-31, 44-69, 83-120, 123-155, 158, 174, 185-193
python/src/training/grpc_errors.py                6      4      2      0    25%   13-17
python/src/training/job_queue.py                 30      1      4      1    94%   31
python/src/training/job_store.py                134     15     52     16    83%   31-32, 43-44, 61->exit, 63->exit, 65->exit, 69->exit, 76->exit, 78->exit, 86->exit, 88->exit, 90->exit, 101, 113, 145, 150-151, 167, 184-185, 191, 204, 221
python/src/training/materialize_features.py      26      6      4      1    77%   45-52
python/src/training/optuna_resume.py             74     18     20      7    71%   23, 31, 55, 65, 89-99, 103-106, 122-123, 147->156, 152-154
python/src/training/postgres_job_store.py       137     48     28      7    59%   27, 32, 40-41, 49, 159-166, 175, 190-240, 243-251, 263-280, 283->289, 286-287, 326, 329-344, 347, 391, 394
python/src/training/schemas.py                  311      3      4      0    98%   368-370
python/src/training/server.py                    52     52      4      0     0%   3-102
python/src/training/service.py                  618    304    218     54    49%   75-76, 79-80, 102-103, 111-112, 122, 125-126, 130-133, 141-142, 144->143, 146, 176, 178, 203, 212, 219->exit, 224-233, 237-488, 492-514, 518-577, 591-605, 607->610, 611-635, 640->661, 648-649, 653, 685->704, 726-728, 732-756, 768-783, 785->788, 789-802, 807->825, 815, 819, 826, 832, 838, 853, 884-964, 972-974, 980, 1011-1012, 1041-1045, 1053, 1055, 1064, 1133-1139, 1152-1158, 1165, 1168, 1172, 1181, 1194->1197, 1223, 1227, 1271, 1288->1290, 1303, 1307, 1309, 1323, 1333, 1357, 1359, 1363-1364, 1369, 1376, 1384->exit, 1389-1392, 1401-1419
python/src/training/tuning_startup.py            79      9     18      2    87%   31-35, 44-49, 53-58
python/src/training/worker.py                   220     36     60     16    80%   27, 38, 73-75, 79-82, 117, 129->134, 137-138, 140, 173, 187, 190, 201, 247-260, 276, 290-296, 301-302, 307, 328, 341->346, 351-352
-----------------------------------------------------------------------------------------
TOTAL                                          5369   1237   1448    272    74%

13 files skipped due to complete coverage.
378 passed, 50 skipped, 49 warnings in 25.92s

#### Risk

Low. This is contract-shape cleanup, test hardening, and docs alignment.

Closes #395
