### PR TITLE
fix(python): ML operability diagnostics polish v6

### DIFF
--- a/docs/inference/model_manager_diagnostics_contract.md
+++ b/docs/inference/model_manager_diagnostics_contract.md
@@ -21,6 +21,7 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 | Field | Type | Notes |
 | --- | --- | --- |
 | `state` | `string` | ModelManager lifecycle state. |
+| `status` | `string` | Canonical operator status (`success`, `failure`, `unknown`, `not_run`). |
 | `model_version` | `string` | Active model version or `"unknown"`. |
 | `model_source` | `string` | Active source (`mlflow`, `fallback`, `none`). |
 | `last_error` | `string \| null` | Last error text when present. |
@@ -40,6 +41,7 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 | `ml.model.version` | `string \| null` | Training-side model version value. |
 | `ml.feature.schema_hash` | `string \| null` | Training-side feature schema hash. |
 | `config` | `object` | Effective strict-mode runtime config (`strict_feature_schema`, `strict_tuning_resume_validation`, `strict_split_strategy_validation`). Also projected to forecast `GetHealth` component flags. |
+| `warnings` | `list[string]` | Compact bounded warning-code summary. |
 | `ml_health` | `object` | Compact bounded operator summary derived from diagnostics + last drift cache snapshot when available. |
 
 ## Nullable Value Conditions (Keys Still Present)
@@ -52,6 +54,7 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 | `benchmark_last_run_ts` | Null until benchmark path has run or skipped. |
 | `benchmark_last_status` | Null until benchmark path has run or skipped. |
 | `feature_coverage_warning_last_seen_ts` | Null until coverage warning has been observed. |
+| `warnings` / `ml_health.warnings` | Always present as a bounded list (possibly empty), never null. |
 | `ml.training.run_id` / `ml.model.version` / `ml.feature.schema_hash` | Null when training identity artifact is unavailable. |
 | `ml_health.model.last_reload_ts` / `ml_health.benchmark.last_status` / `ml_health.benchmark.last_run_ts` / `ml_health.drift.last_error_code` / legacy aliases (`ml_health.last_reload_ts`, `ml_health.benchmark_status`, `ml_health.drift_last_computed_ts`, `ml_health.drift_last_error_code`) | Null when source value has not been observed yet. |
 | `ml_health.drift_reference_available` | Null when no drift run has been cached yet. |
@@ -63,6 +66,12 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 - `loading`
 - `ready`
 - `failed`
+
+`status` (canonical operator summary on diagnostics + `ml_health`):
+- `success`
+- `failure`
+- `unknown`
+- `not_run`
 
 `last_reload_status`:
 - `idle`
@@ -79,6 +88,7 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 - `skipped_sampled_out`
 - `success`
 - `failed`
+- `unknown`
 
 `degraded_reasons` (bounded list values):
 - `reload_failed`
@@ -93,6 +103,12 @@ These keys are guaranteed to exist for operability guardrails, including idle st
 `ml_health.feature_coverage_status`:
 - `ok`
 - `warning`
+
+`warnings` / `ml_health.warnings` (bounded list values):
+- `schema_mismatch_detected`
+- `reload_failed_using_last_known_good`
+- `feature_coverage_below_threshold`
+- `drift_reference_unavailable`
 
 `ml_health.drift.reference_resolution_mode` and legacy alias `ml_health.drift_resolution_mode`:
 - `alias`
@@ -122,6 +138,7 @@ backward compatibility.
   - `last_ratio`
   - `below_threshold`
 - `config`
+- `warnings` (bounded list of warning codes)
 
 `ml_health.config` keys (always present, default `false`):
 
@@ -153,6 +170,11 @@ Legacy aliases retained in `ml_health`:
 - `drift_last_computed_ts`
 - `drift_last_error_code`
 
+Additional canonical top-level summary fields in `ml_health`:
+
+- `status`
+- `warnings`
+
 `ml_health.feature_coverage.last_ratio` semantics:
 
 - Bounded float in `[0.0, 1.0]` when observed.
@@ -182,6 +204,11 @@ Core top-level keys (always present):
 - `alerts`
 - `reference_resolution`
 - `reference_model_version`
+- `reference_resolution_mode_requested`
+- `reference_resolution_mode`
+- `reference_model_version_chosen`
+- `reference_alias_requested`
+- `reference_resolution_warning`
 
 Field semantics:
 
@@ -189,7 +216,12 @@ Field semantics:
 - `error_message`: short operator-facing message or `null`, capped at 200 chars.
 - `error`: legacy alias that mirrors `error_message` (`null` on no-error paths).
 - `resolution_mode`: canonical reference resolution mode.
+- `reference_resolution_mode_requested`: requested reference-resolution mode.
+- `reference_resolution_mode`: resolved reference-resolution mode (mirrors `resolution_mode`).
 - `reference_model_version`: selected reference model version when available.
+- `reference_model_version_chosen`: additive alias for selected reference model version.
+- `reference_alias_requested`: requested alias (when configured).
+- `reference_resolution_warning`: bounded optional warning code explaining fallback/ambiguity.
 - `drift_error`: legacy drift code mirror (set when canonical `error_code` is set).
 
 `reference_resolution` shape (always present):
@@ -278,6 +310,19 @@ Notes:
 - `alias_candidate_count` is always an integer (default `0`).
 - `alias_ambiguous` is always a boolean (default `false`).
 
+Top-level reference metadata clarifies requested vs resolved outcomes:
+
+- `reference_resolution_mode_requested`: canonical requested mode.
+- `reference_resolution_mode`: canonical resolved mode (same as `resolution_mode`).
+- `reference_model_version_chosen`: chosen model version (`null` when unresolved).
+- `reference_alias_requested`: requested alias (`null` when not configured).
+- `reference_resolution_warning`: optional bounded warning code:
+  - `alias_not_found_fallback`
+  - `alias_ambiguous_selected_highest`
+  - `stage_fallback_used`
+  - `latest_fallback_used`
+  - `no_reference_versions_available`
+
 ### Per-Feature Bucketing Metadata (When Feature Is Evaluated)
 
 Each `features.<name>.bucketing` map includes:
@@ -301,6 +346,7 @@ Each `features.<name>.bucketing` map includes:
 ```json
 {
   "state": "ready",
+  "status": "success",
   "model_version": "v17",
   "model_source": "mlflow",
   "last_error": null,
@@ -325,6 +371,7 @@ Each `features.<name>.bucketing` map includes:
     "strict_tuning_resume_validation": false,
     "strict_split_strategy_validation": false
   },
+  "warnings": [],
   "ml_health": {
     "model": {
       "state": "ready",
@@ -351,6 +398,8 @@ Each `features.<name>.bucketing` map includes:
       "strict_tuning_resume_validation": false,
       "strict_split_strategy_validation": false
     },
+    "warnings": [],
+    "status": "success",
     "state": "ready",
     "active_model_version": "v17",
     "last_reload_status": "success",
@@ -413,6 +462,11 @@ Each `features.<name>.bucketing` map includes:
     "selected_model_version": "9",
     "selected_run_id": "run-v9"
   },
-  "reference_model_version": "9"
+  "reference_model_version": "9",
+  "reference_resolution_mode_requested": "alias",
+  "reference_resolution_mode": "alias",
+  "reference_model_version_chosen": "9",
+  "reference_alias_requested": "champion",
+  "reference_resolution_warning": null
 }
 ```

--- a/python/src/forecast/model_manager.py
+++ b/python/src/forecast/model_manager.py
@@ -45,6 +45,7 @@ from training.reason_codes import (
     DIAGNOSTIC_KEY_SCHEMA_MISMATCH_DETECTED,
     DIAGNOSTIC_KEY_STATE,
     DIAGNOSTIC_KEY_STATUS,
+    DIAGNOSTIC_KEY_WARNINGS,
     TRACE_KEY_ML_FEATURE_SCHEMA_HASH,
     TRACE_KEY_ML_MODEL_VERSION,
     TRACE_KEY_ML_TRAINING_RUN_ID,
@@ -55,6 +56,7 @@ from training.reason_codes import (
     TRAINING_IDENTITY_KEY_SCHEMA_VERSION,
     BenchmarkStatus,
     DiagnosticsDegradedReason,
+    DiagnosticsWarningCode,
     ModelManagerState,
     OperabilityStatus,
     ReloadFailureReason,
@@ -147,6 +149,7 @@ class ModelManager:
         "drift",
         "feature_coverage",
         "config",
+        "warnings",
         "status",
         "state",
         "active_model_version",
@@ -513,6 +516,33 @@ class ModelManager:
             return "latest"
         return "none"
 
+    @classmethod
+    def _normalize_warning_codes(cls, raw_warnings: Any) -> list[str]:
+        if isinstance(raw_warnings, str):
+            candidates: list[Any] = [raw_warnings]
+        elif isinstance(raw_warnings, list | tuple | set):
+            candidates = list(raw_warnings)
+        else:
+            candidates = []
+        normalized: list[str] = []
+        for candidate in candidates:
+            warning = cls._bounded_optional_str(candidate, max_len=64)
+            if warning is None:
+                continue
+            warning = warning.lower()
+            if warning not in {
+                DiagnosticsWarningCode.SCHEMA_MISMATCH_DETECTED.value,
+                DiagnosticsWarningCode.RELOAD_FAILED_USING_LAST_KNOWN_GOOD.value,
+                DiagnosticsWarningCode.FEATURE_COVERAGE_BELOW_THRESHOLD.value,
+                DiagnosticsWarningCode.DRIFT_REFERENCE_UNAVAILABLE.value,
+            }:
+                continue
+            if warning not in normalized:
+                normalized.append(warning)
+            if len(normalized) >= 4:
+                break
+        return normalized
+
     @staticmethod
     def _normalize_benchmark_last_status(raw_status: Any) -> str | None:
         normalized = ModelManager._bounded_optional_str(raw_status, max_len=32)
@@ -764,6 +794,16 @@ class ModelManager:
             diagnostics_snapshot.get(DIAGNOSTIC_KEY_STATUS),
             fallback_state=model_state,
         )
+        warnings = self._normalize_warning_codes(
+            diagnostics_snapshot.get(DIAGNOSTIC_KEY_WARNINGS)
+        )
+        if drift_reference_available is False:
+            warnings = self._normalize_warning_codes(
+                [
+                    *warnings,
+                    DiagnosticsWarningCode.DRIFT_REFERENCE_UNAVAILABLE.value,
+                ]
+            )
 
         # Keep legacy scalar aliases for compatibility with existing consumers.
         payload = {
@@ -772,6 +812,7 @@ class ModelManager:
             "drift": drift_summary,
             "feature_coverage": feature_coverage_summary,
             "config": strict_config,
+            "warnings": warnings,
             "status": health_status,
             "state": model_summary["state"],
             "active_model_version": model_summary["active_model_version"],
@@ -907,8 +948,30 @@ class ModelManager:
                     self._effective_strict_config()
                 ),
             }
+            diagnostics[DIAGNOSTIC_KEY_WARNINGS] = self._normalize_warning_codes(
+                [
+                    DiagnosticsWarningCode.SCHEMA_MISMATCH_DETECTED.value
+                    if self.schema_mismatch_detected
+                    else None,
+                    DiagnosticsWarningCode.FEATURE_COVERAGE_BELOW_THRESHOLD.value
+                    if self._feature_coverage_warning_active
+                    else None,
+                    DiagnosticsWarningCode.RELOAD_FAILED_USING_LAST_KNOWN_GOOD.value
+                    if (
+                        self.model_source == "fallback"
+                        or (
+                            self._state == ModelManagerState.FAILED.value
+                            and bundle is not None
+                        )
+                    )
+                    else None,
+                ]
+            )
             diagnostics[DIAGNOSTIC_KEY_ML_HEALTH] = self._build_ml_health_summary(
                 diagnostics
+            )
+            diagnostics[DIAGNOSTIC_KEY_WARNINGS] = self._normalize_warning_codes(
+                diagnostics[DIAGNOSTIC_KEY_ML_HEALTH].get("warnings")
             )
             return diagnostics
 

--- a/python/src/forecast/model_manager.py
+++ b/python/src/forecast/model_manager.py
@@ -44,6 +44,7 @@ from training.reason_codes import (
     DIAGNOSTIC_KEY_MODEL_VERSION,
     DIAGNOSTIC_KEY_SCHEMA_MISMATCH_DETECTED,
     DIAGNOSTIC_KEY_STATE,
+    DIAGNOSTIC_KEY_STATUS,
     TRACE_KEY_ML_FEATURE_SCHEMA_HASH,
     TRACE_KEY_ML_MODEL_VERSION,
     TRACE_KEY_ML_TRAINING_RUN_ID,
@@ -55,6 +56,7 @@ from training.reason_codes import (
     BenchmarkStatus,
     DiagnosticsDegradedReason,
     ModelManagerState,
+    OperabilityStatus,
     ReloadFailureReason,
     ReloadStatus,
 )
@@ -145,6 +147,7 @@ class ModelManager:
         "drift",
         "feature_coverage",
         "config",
+        "status",
         "state",
         "active_model_version",
         "last_reload_status",
@@ -511,6 +514,50 @@ class ModelManager:
         return "none"
 
     @staticmethod
+    def _normalize_benchmark_last_status(raw_status: Any) -> str | None:
+        normalized = ModelManager._bounded_optional_str(raw_status, max_len=32)
+        if normalized is None:
+            return None
+        normalized = normalized.lower()
+        if normalized in {
+            BenchmarkStatus.SKIPPED_DISABLED.value,
+            BenchmarkStatus.SKIPPED_SAMPLED_OUT.value,
+            BenchmarkStatus.SUCCESS.value,
+            BenchmarkStatus.FAILED.value,
+            BenchmarkStatus.UNKNOWN.value,
+        }:
+            return normalized
+        return BenchmarkStatus.UNKNOWN.value
+
+    @staticmethod
+    def _normalize_operability_status(raw_status: Any, *, fallback_state: Any) -> str:
+        normalized = (
+            ModelManager._bounded_optional_str(raw_status, max_len=16)
+            if raw_status is not None
+            else None
+        )
+        if normalized is not None:
+            normalized = normalized.lower()
+            if normalized in {
+                OperabilityStatus.SUCCESS.value,
+                OperabilityStatus.FAILURE.value,
+                OperabilityStatus.UNKNOWN.value,
+                OperabilityStatus.NOT_RUN.value,
+            }:
+                return normalized
+
+        state = (
+            str(fallback_state).strip().lower() if fallback_state is not None else ""
+        )
+        if state == ModelManagerState.READY.value:
+            return OperabilityStatus.SUCCESS.value
+        if state == ModelManagerState.FAILED.value:
+            return OperabilityStatus.FAILURE.value
+        if state == ModelManagerState.IDLE.value:
+            return OperabilityStatus.NOT_RUN.value
+        return OperabilityStatus.UNKNOWN.value
+
+    @staticmethod
     def _bounded_optional_str(value: Any, *, max_len: int) -> str | None:
         if value is None:
             return None
@@ -654,13 +701,14 @@ class ModelManager:
         strict_config = self._normalize_strict_config(
             diagnostics_snapshot.get(DIAGNOSTIC_KEY_CONFIG)
         )
+        model_state = self._bounded_str(
+            diagnostics_snapshot.get(DIAGNOSTIC_KEY_STATE),
+            default=ModelManagerState.IDLE.value,
+            max_len=32,
+        )
 
         model_summary = {
-            "state": self._bounded_str(
-                diagnostics_snapshot.get(DIAGNOSTIC_KEY_STATE),
-                default="idle",
-                max_len=32,
-            ),
+            "state": model_state,
             "active_model_version": self._bounded_str(
                 diagnostics_snapshot.get(DIAGNOSTIC_KEY_ACTIVE_MODEL_VERSION),
                 default="unknown",
@@ -712,6 +760,10 @@ class ModelManager:
                 max_len=64,
             ),
         }
+        health_status = self._normalize_operability_status(
+            diagnostics_snapshot.get(DIAGNOSTIC_KEY_STATUS),
+            fallback_state=model_state,
+        )
 
         # Keep legacy scalar aliases for compatibility with existing consumers.
         payload = {
@@ -720,6 +772,7 @@ class ModelManager:
             "drift": drift_summary,
             "feature_coverage": feature_coverage_summary,
             "config": strict_config,
+            "status": health_status,
             "state": model_summary["state"],
             "active_model_version": model_summary["active_model_version"],
             "last_reload_status": model_summary["last_reload_status"],
@@ -800,6 +853,10 @@ class ModelManager:
                     DiagnosticsDegradedReason.FEATURE_COVERAGE_WARNING.value
                 )
             diagnostics = {
+                DIAGNOSTIC_KEY_STATUS: self._normalize_operability_status(
+                    None,
+                    fallback_state=self._state,
+                ),
                 DIAGNOSTIC_KEY_STATE: self._state,
                 DIAGNOSTIC_KEY_MODEL_VERSION: self.model_version,
                 DIAGNOSTIC_KEY_MODEL_SOURCE: self.model_source,
@@ -807,7 +864,9 @@ class ModelManager:
                 DIAGNOSTIC_KEY_SCHEMA_MISMATCH_DETECTED: self.schema_mismatch_detected,
                 DIAGNOSTIC_KEY_CALIBRATOR_LOADED: self.calibrator_loaded,
                 DIAGNOSTIC_KEY_HAS_BUNDLE: bundle is not None,
-                DIAGNOSTIC_KEY_LAST_RELOAD_TS: getattr(bundle, "last_reload_ts", None)
+                DIAGNOSTIC_KEY_LAST_RELOAD_TS: self._coerce_float_or_none(
+                    getattr(bundle, "last_reload_ts", None)
+                )
                 if bundle
                 else None,
                 DIAGNOSTIC_KEY_LAST_RELOAD_STATUS: last_reload_status,
@@ -816,8 +875,12 @@ class ModelManager:
                     if last_reload_status == ReloadStatus.FAILED.value
                     else None
                 ),
-                DIAGNOSTIC_KEY_BENCHMARK_LAST_RUN_TS: self._benchmark_last_run_ts,
-                DIAGNOSTIC_KEY_BENCHMARK_LAST_STATUS: self._benchmark_last_status,
+                DIAGNOSTIC_KEY_BENCHMARK_LAST_RUN_TS: self._coerce_float_or_none(
+                    self._benchmark_last_run_ts
+                ),
+                DIAGNOSTIC_KEY_BENCHMARK_LAST_STATUS: (
+                    self._normalize_benchmark_last_status(self._benchmark_last_status)
+                ),
                 DIAGNOSTIC_KEY_DEGRADED_REASONS: degraded_reasons,
                 DIAGNOSTIC_KEY_ACTIVE_MODEL_VERSION: self.model_version,
                 DIAGNOSTIC_KEY_FEATURE_COVERAGE_WARNING_ACTIVE: (
@@ -827,7 +890,9 @@ class ModelManager:
                     self._feature_coverage_last_ratio
                 ),
                 DIAGNOSTIC_KEY_FEATURE_COVERAGE_WARNING_LAST_SEEN_TS: (
-                    self._feature_coverage_warning_last_seen_ts
+                    self._coerce_float_or_none(
+                        self._feature_coverage_warning_last_seen_ts
+                    )
                 ),
                 DIAGNOSTIC_KEY_ML_TRAINING_RUN_ID: training_identity.get(
                     TRAINING_IDENTITY_KEY_MLFLOW_RUN_ID

--- a/python/src/training/detect_drift.py
+++ b/python/src/training/detect_drift.py
@@ -115,6 +115,16 @@ MAX_DRIFT_REFERENCE_RUN_ID_LENGTH = MAX_REFERENCE_RUN_ID_LENGTH
 MAX_DRIFT_REFERENCE_ALIAS_LENGTH = MAX_REFERENCE_METADATA_TEXT_LENGTH
 MAX_DRIFT_BUCKETTYPE_LENGTH = 24
 MAX_DRIFT_BREAKPOINTS = MAX_BREAKPOINTS_COUNT
+MAX_REFERENCE_RESOLUTION_WARNING_LENGTH = 64
+REFERENCE_RESOLUTION_WARNING_CODES = frozenset(
+    {
+        "alias_not_found_fallback",
+        "alias_ambiguous_selected_highest",
+        "stage_fallback_used",
+        "latest_fallback_used",
+        "no_reference_versions_available",
+    }
+)
 _DEFAULT_DRIFT_ERROR_MESSAGES = {
     DriftErrorCode.NO_REFERENCE_DATA.value: "No reference data available",
     DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value: (
@@ -322,17 +332,21 @@ def _select_reference_model_version(
     """
     metadata: dict[str, Any] = {
         "requested_alias": None,
+        "requested_mode": DriftResolutionMode.STAGE.value,
         "resolution_strategy": None,
+        "resolution_warning": None,
         "alias_candidate_count": 0,
         "alias_ambiguous": False,
     }
 
     if not versions:
+        metadata["resolution_warning"] = "no_reference_versions_available"
         return None, metadata
 
     normalized_alias = str(alias_name or "").strip().lstrip("@")
     if normalized_alias:
         metadata["requested_alias"] = normalized_alias
+        metadata["requested_mode"] = DriftResolutionMode.ALIAS.value
         alias_candidates = [
             version
             for version in versions
@@ -348,6 +362,7 @@ def _select_reference_model_version(
             metadata["alias_ambiguous"] = len(alias_candidates_sorted) > 1
             selected_alias_version = alias_candidates_sorted[0]
             if metadata["alias_ambiguous"]:
+                metadata["resolution_warning"] = "alias_ambiguous_selected_highest"
                 logger.warning(
                     "Drift alias '@%s' resolved to %s candidates; selecting highest "
                     "version deterministically (%s).",
@@ -362,6 +377,7 @@ def _select_reference_model_version(
             "falling back to stage/latest resolution.",
             normalized_alias,
         )
+        metadata["resolution_warning"] = "alias_not_found_fallback"
 
     stage_candidates = [
         version
@@ -373,6 +389,8 @@ def _select_reference_model_version(
             stage_candidates, key=_safe_model_version_number, reverse=True
         )[0]
         metadata["resolution_strategy"] = "production_stage"
+        if metadata.get("resolution_warning") is None:
+            metadata["resolution_warning"] = "stage_fallback_used"
 
         global _DRIFT_STAGE_FALLBACK_WARNED
         if not _DRIFT_STAGE_FALLBACK_WARNED:
@@ -387,6 +405,8 @@ def _select_reference_model_version(
 
     selected_latest = sorted(versions, key=_safe_model_version_number, reverse=True)[0]
     metadata["resolution_strategy"] = "latest_version"
+    if metadata.get("resolution_warning") is None:
+        metadata["resolution_warning"] = "latest_fallback_used"
 
     global _DRIFT_LATEST_FALLBACK_WARNED
     if not _DRIFT_LATEST_FALLBACK_WARNED:
@@ -409,6 +429,36 @@ def _normalize_resolution_mode(raw_strategy: Any) -> str:
     if normalized in _LEGACY_RESOLUTION_MODE_ALIASES:
         return _LEGACY_RESOLUTION_MODE_ALIASES[normalized]
     return DriftResolutionMode.NONE.value
+
+
+def _normalize_requested_resolution_mode(
+    raw_mode: Any,
+    *,
+    requested_alias: Any,
+) -> str:
+    normalized = _normalize_resolution_mode(raw_mode)
+    if normalized != DriftResolutionMode.NONE.value:
+        return normalized
+    alias = _bounded_optional_text(
+        requested_alias,
+        max_len=MAX_REFERENCE_METADATA_TEXT_LENGTH,
+    )
+    if alias is not None:
+        return DriftResolutionMode.ALIAS.value
+    return DriftResolutionMode.STAGE.value
+
+
+def _normalize_reference_resolution_warning(raw_warning: Any) -> str | None:
+    warning = _bounded_optional_text(
+        raw_warning,
+        max_len=MAX_REFERENCE_RESOLUTION_WARNING_LENGTH,
+    )
+    if warning is None:
+        return None
+    warning = warning.lower()
+    if warning not in REFERENCE_RESOLUTION_WARNING_CODES:
+        return None
+    return warning
 
 
 def _bounded_metadata_text(value: Any, *, max_len: int) -> str | None:
@@ -650,6 +700,11 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
     results.setdefault("drift_error", None)
     results.setdefault("reference_resolution", {})
     results.setdefault("reference_model_version", None)
+    results.setdefault("reference_resolution_mode_requested", None)
+    results.setdefault("reference_resolution_mode", None)
+    results.setdefault("reference_model_version_chosen", None)
+    results.setdefault("reference_alias_requested", None)
+    results.setdefault("reference_resolution_warning", None)
     raw_resolution_mode = _normalize_resolution_mode(results.get("resolution_mode"))
     reference_resolution = _normalize_reference_resolution_metadata(
         results.get("reference_resolution"),
@@ -710,6 +765,42 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
     results["reference_model_version"] = reference_model_version
     if reference_resolution.get("selected_model_version") is None:
         reference_resolution["selected_model_version"] = reference_model_version
+
+    requested_alias = _bounded_optional_text(
+        results.get("reference_alias_requested"),
+        max_len=MAX_REFERENCE_METADATA_TEXT_LENGTH,
+    )
+    if requested_alias is None:
+        requested_alias = _bounded_optional_text(
+            reference_resolution.get("requested_alias"),
+            max_len=MAX_REFERENCE_METADATA_TEXT_LENGTH,
+        )
+    results["reference_alias_requested"] = requested_alias
+    requested_mode = _normalize_requested_resolution_mode(
+        results.get("reference_resolution_mode_requested"),
+        requested_alias=requested_alias,
+    )
+    results["reference_resolution_mode_requested"] = requested_mode
+    results["reference_resolution_mode"] = normalized_resolution_mode
+    results["reference_model_version_chosen"] = reference_model_version
+
+    reference_resolution_warning = _normalize_reference_resolution_warning(
+        results.get("reference_resolution_warning")
+    )
+    if (
+        reference_resolution_warning is None
+        and requested_mode == DriftResolutionMode.ALIAS.value
+        and normalized_resolution_mode
+        in {DriftResolutionMode.STAGE.value, DriftResolutionMode.LATEST.value}
+    ):
+        reference_resolution_warning = "alias_not_found_fallback"
+    if (
+        reference_resolution_warning is None
+        and normalized_resolution_mode == DriftResolutionMode.NONE.value
+        and reference_model_version is None
+    ):
+        reference_resolution_warning = "no_reference_versions_available"
+    results["reference_resolution_warning"] = reference_resolution_warning
 
     return results
 
@@ -807,6 +898,14 @@ def detect_drift(
 ) -> dict[str, Any]:
     """Run drift detection."""
     initial_reference_resolution = _normalize_reference_resolution({})
+    initial_requested_alias = _bounded_optional_text(
+        DRIFT_REFERENCE_MODEL_ALIAS.lstrip("@"),
+        max_len=MAX_REFERENCE_METADATA_TEXT_LENGTH,
+    )
+    initial_requested_mode = _normalize_requested_resolution_mode(
+        None,
+        requested_alias=initial_requested_alias,
+    )
     results = {
         "timestamp": datetime.now(UTC).isoformat(),
         "hours_analyzed": hours,
@@ -824,12 +923,35 @@ def detect_drift(
         "alerts": [],
         "reference_resolution": initial_reference_resolution,
         "reference_model_version": None,
+        "reference_resolution_mode_requested": initial_requested_mode,
+        "reference_resolution_mode": DriftResolutionMode.NONE.value,
+        "reference_model_version_chosen": None,
+        "reference_alias_requested": initial_requested_alias,
+        "reference_resolution_warning": None,
     }
 
     reference_result = get_reference_data(include_metadata=True)
     reference_resolution: dict[str, Any] = initial_reference_resolution
     if isinstance(reference_result, tuple):
         df_reference, raw_reference_resolution = reference_result
+        if isinstance(raw_reference_resolution, dict):
+            results["reference_resolution_mode_requested"] = (
+                _normalize_requested_resolution_mode(
+                    raw_reference_resolution.get("requested_mode"),
+                    requested_alias=raw_reference_resolution.get("requested_alias")
+                    or initial_requested_alias,
+                )
+            )
+            results["reference_alias_requested"] = _bounded_optional_text(
+                raw_reference_resolution.get("requested_alias")
+                or initial_requested_alias,
+                max_len=MAX_REFERENCE_METADATA_TEXT_LENGTH,
+            )
+            results["reference_resolution_warning"] = (
+                _normalize_reference_resolution_warning(
+                    raw_reference_resolution.get("resolution_warning")
+                )
+            )
         reference_resolution = _normalize_reference_resolution(raw_reference_resolution)
     else:
         df_reference = reference_result
@@ -842,6 +964,7 @@ def detect_drift(
         reference_resolution.get("resolution_mode")
         or reference_resolution.get("resolution_strategy")
     )
+    results["reference_resolution_mode"] = results["resolution_mode"]
 
     if df_reference is None or len(df_reference) == 0:
         _set_canonical_error(

--- a/python/src/training/reason_codes.py
+++ b/python/src/training/reason_codes.py
@@ -104,6 +104,15 @@ class DiagnosticsDegradedReason(str, Enum):
     FEATURE_COVERAGE_WARNING = "feature_coverage_warning"
 
 
+class DiagnosticsWarningCode(str, Enum):
+    """Compact bounded warning codes for operator-facing diagnostics summaries."""
+
+    SCHEMA_MISMATCH_DETECTED = "schema_mismatch_detected"
+    RELOAD_FAILED_USING_LAST_KNOWN_GOOD = "reload_failed_using_last_known_good"
+    FEATURE_COVERAGE_BELOW_THRESHOLD = "feature_coverage_below_threshold"
+    DRIFT_REFERENCE_UNAVAILABLE = "drift_reference_unavailable"
+
+
 RELOAD_FAILURE_REASONS = frozenset(reason.value for reason in ReloadFailureReason)
 SCHEMA_MISMATCH_REASONS = frozenset(reason.value for reason in SchemaMismatchReason)
 CALIBRATION_SKIP_REASONS = frozenset(reason.value for reason in CalibrationSkipReason)
@@ -118,10 +127,12 @@ RESUME_VALIDATION_REASONS = frozenset(reason.value for reason in ResumeValidatio
 DIAGNOSTICS_DEGRADED_REASONS = frozenset(
     reason.value for reason in DiagnosticsDegradedReason
 )
+DIAGNOSTICS_WARNING_CODES = frozenset(reason.value for reason in DiagnosticsWarningCode)
 
 # Diagnostics snapshot keys used by ModelManager.get_diagnostics().
 DIAGNOSTIC_KEY_STATE = "state"
 DIAGNOSTIC_KEY_STATUS = "status"
+DIAGNOSTIC_KEY_WARNINGS = "warnings"
 DIAGNOSTIC_KEY_MODEL_VERSION = "model_version"
 DIAGNOSTIC_KEY_MODEL_SOURCE = "model_source"
 DIAGNOSTIC_KEY_LAST_ERROR = "last_error"

--- a/python/src/training/reason_codes.py
+++ b/python/src/training/reason_codes.py
@@ -59,6 +59,7 @@ class BenchmarkStatus(str, Enum):
     SKIPPED_SAMPLED_OUT = "skipped_sampled_out"
     SUCCESS = "success"
     FAILED = "failed"
+    UNKNOWN = "unknown"
 
 
 class ModelManagerState(str, Enum):
@@ -76,6 +77,15 @@ class ReloadStatus(str, Enum):
     IDLE = "idle"
     SUCCESS = "success"
     FAILED = "failed"
+
+
+class OperabilityStatus(str, Enum):
+    """Canonical operator-facing status vocabulary for health summaries."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    UNKNOWN = "unknown"
+    NOT_RUN = "not_run"
 
 
 class ResumeValidationReason(str, Enum):
@@ -103,6 +113,7 @@ DRIFT_RESOLUTION_MODES = frozenset(reason.value for reason in DriftResolutionMod
 BENCHMARK_STATUSES = frozenset(reason.value for reason in BenchmarkStatus)
 MODEL_MANAGER_STATES = frozenset(reason.value for reason in ModelManagerState)
 RELOAD_STATUSES = frozenset(reason.value for reason in ReloadStatus)
+OPERABILITY_STATUSES = frozenset(reason.value for reason in OperabilityStatus)
 RESUME_VALIDATION_REASONS = frozenset(reason.value for reason in ResumeValidationReason)
 DIAGNOSTICS_DEGRADED_REASONS = frozenset(
     reason.value for reason in DiagnosticsDegradedReason
@@ -110,6 +121,7 @@ DIAGNOSTICS_DEGRADED_REASONS = frozenset(
 
 # Diagnostics snapshot keys used by ModelManager.get_diagnostics().
 DIAGNOSTIC_KEY_STATE = "state"
+DIAGNOSTIC_KEY_STATUS = "status"
 DIAGNOSTIC_KEY_MODEL_VERSION = "model_version"
 DIAGNOSTIC_KEY_MODEL_SOURCE = "model_source"
 DIAGNOSTIC_KEY_LAST_ERROR = "last_error"

--- a/python/tests/inference/test_model_manager_diagnostics.py
+++ b/python/tests/inference/test_model_manager_diagnostics.py
@@ -191,6 +191,7 @@ class TestModelManagerDiagnostics:
         assert {"model", "benchmark", "drift", "feature_coverage"}.issubset(
             health.keys()
         )
+        assert isinstance(health["warnings"], list)
         assert health["status"] in OPERABILITY_STATUSES
         assert set(health["model"].keys()) == {
             "state",
@@ -263,6 +264,7 @@ class TestModelManagerDiagnostics:
             "drift",
             "feature_coverage",
             "config",
+            "warnings",
             "status",
             "state",
             "active_model_version",
@@ -278,6 +280,7 @@ class TestModelManagerDiagnostics:
             "drift_last_error_code",
         }
         assert health["benchmark_status"] is None
+        assert health["warnings"] == []
         assert health["status"] in OPERABILITY_STATUSES
         assert health["drift"]["last_error_code"] is None
         assert health["drift_last_error_code"] is None

--- a/python/tests/inference/test_model_manager_diagnostics.py
+++ b/python/tests/inference/test_model_manager_diagnostics.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from forecast.model_manager import ModelManager
+from training.reason_codes import OPERABILITY_STATUSES
 
 
 class TestModelManagerDiagnostics:
@@ -190,6 +191,7 @@ class TestModelManagerDiagnostics:
         assert {"model", "benchmark", "drift", "feature_coverage"}.issubset(
             health.keys()
         )
+        assert health["status"] in OPERABILITY_STATUSES
         assert set(health["model"].keys()) == {
             "state",
             "active_model_version",
@@ -261,6 +263,7 @@ class TestModelManagerDiagnostics:
             "drift",
             "feature_coverage",
             "config",
+            "status",
             "state",
             "active_model_version",
             "last_reload_status",
@@ -275,6 +278,7 @@ class TestModelManagerDiagnostics:
             "drift_last_error_code",
         }
         assert health["benchmark_status"] is None
+        assert health["status"] in OPERABILITY_STATUSES
         assert health["drift"]["last_error_code"] is None
         assert health["drift_last_error_code"] is None
         assert health["drift_last_computed_ts"] is None

--- a/python/tests/inference/test_model_manager_diagnostics.py
+++ b/python/tests/inference/test_model_manager_diagnostics.py
@@ -280,7 +280,7 @@ class TestModelManagerDiagnostics:
             "drift_last_error_code",
         }
         assert health["benchmark_status"] is None
-        assert health["warnings"] == []
+        assert health["warnings"] == ["drift_reference_unavailable"]
         assert health["status"] in OPERABILITY_STATUSES
         assert health["drift"]["last_error_code"] is None
         assert health["drift_last_error_code"] is None

--- a/python/tests/model/test_reason_codes.py
+++ b/python/tests/model/test_reason_codes.py
@@ -40,6 +40,7 @@ def test_reason_code_vocabulary_is_stable():
         "skipped_sampled_out",
         "success",
         "failed",
+        "unknown",
     }
     assert DIAGNOSTICS_DEGRADED_REASONS == {
         "reload_failed",

--- a/python/tests/test_contract_compatibility_guards.py
+++ b/python/tests/test_contract_compatibility_guards.py
@@ -70,6 +70,11 @@ DRIFT_RESULT_KEYS = {
     "alerts",
     "reference_resolution",
     "reference_model_version",
+    "reference_resolution_mode_requested",
+    "reference_resolution_mode",
+    "reference_model_version_chosen",
+    "reference_alias_requested",
+    "reference_resolution_warning",
 }
 REFERENCE_RESOLUTION_KEYS = {
     "requested_alias",
@@ -276,12 +281,26 @@ def test_drift_contract_guard_shape_across_modes(
     assert result["error_code"] == expected_code
     assert result["resolution_mode"] == expected_mode
     assert result["reference_model_version"] == expected_version
+    assert result["reference_model_version_chosen"] == expected_version
     assert isinstance(result["timestamp"], str)
     assert (
         result["error_message"] is None
         or len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH
     )
     assert set(result["reference_resolution"].keys()) == REFERENCE_RESOLUTION_KEYS
+    assert result["reference_resolution_mode"] == result["resolution_mode"]
+    assert result["reference_resolution_mode_requested"] in {
+        DriftResolutionMode.ALIAS.value,
+        DriftResolutionMode.STAGE.value,
+        DriftResolutionMode.LATEST.value,
+        DriftResolutionMode.NONE.value,
+    }
+    assert result["reference_alias_requested"] is None or isinstance(
+        result["reference_alias_requested"], str
+    )
+    assert result["reference_resolution_warning"] is None or isinstance(
+        result["reference_resolution_warning"], str
+    )
     assert (
         result["reference_resolution"]["resolution_mode"] == result["resolution_mode"]
     )

--- a/python/tests/test_contract_compatibility_guards.py
+++ b/python/tests/test_contract_compatibility_guards.py
@@ -22,6 +22,7 @@ ML_HEALTH_KEYS = {
     "drift",
     "feature_coverage",
     "config",
+    "status",
     "state",
     "active_model_version",
     "last_reload_status",
@@ -139,6 +140,7 @@ def test_ml_health_contract_guard_shape_types_and_bounds():
     assert set(health["config"].keys()) == ML_HEALTH_CONFIG_KEYS
 
     assert isinstance(health["state"], str)
+    assert health["status"] in {"success", "failure", "unknown", "not_run"}
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
     assert len(health["active_model_version"]) <= 64

--- a/python/tests/test_contract_compatibility_guards.py
+++ b/python/tests/test_contract_compatibility_guards.py
@@ -22,6 +22,7 @@ ML_HEALTH_KEYS = {
     "drift",
     "feature_coverage",
     "config",
+    "warnings",
     "status",
     "state",
     "active_model_version",
@@ -140,6 +141,15 @@ def test_ml_health_contract_guard_shape_types_and_bounds():
     assert set(health["config"].keys()) == ML_HEALTH_CONFIG_KEYS
 
     assert isinstance(health["state"], str)
+    assert isinstance(health["warnings"], list)
+    assert set(health["warnings"]).issubset(
+        {
+            "schema_mismatch_detected",
+            "reload_failed_using_last_known_good",
+            "feature_coverage_below_threshold",
+            "drift_reference_unavailable",
+        }
+    )
     assert health["status"] in {"success", "failure", "unknown", "not_run"}
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
@@ -178,7 +188,8 @@ def test_ml_health_contract_guard_shape_types_and_bounds():
     assert all(
         not isinstance(value, list | tuple | set)
         for key, value in health.items()
-        if key not in {"model", "benchmark", "drift", "feature_coverage", "config"}
+        if key
+        not in {"model", "benchmark", "drift", "feature_coverage", "config", "warnings"}
     )
 
 

--- a/python/tests/test_detect_drift.py
+++ b/python/tests/test_detect_drift.py
@@ -36,6 +36,11 @@ DRIFT_RESULT_CORE_KEYS = {
     "alerts",
     "reference_resolution",
     "reference_model_version",
+    "reference_resolution_mode_requested",
+    "reference_resolution_mode",
+    "reference_model_version_chosen",
+    "reference_alias_requested",
+    "reference_resolution_warning",
 }
 REFERENCE_RESOLUTION_KEYS = {
     "requested_alias",
@@ -427,6 +432,96 @@ class TestReferenceResolution:
         assert result["reference_resolution"]["selected_model_version"] == "9"
         assert result["reference_resolution"]["selected_run_id"] == "run-v9"
 
+    @patch("training.detect_drift.get_live_data")
+    @patch("training.detect_drift.get_reference_data")
+    def test_reference_metadata_fields_when_alias_requested_and_used(
+        self, mock_reference, mock_live
+    ):
+        stable_df = pd.DataFrame(
+            {
+                "velocity_24h": np.arange(1000, dtype=float),
+                "amount_to_avg_ratio_30d": np.arange(1000, dtype=float) * 0.5,
+                "balance_volatility_z_score": np.arange(1000, dtype=float) - 250.0,
+            }
+        )
+        mock_reference.return_value = (
+            stable_df,
+            {
+                "requested_alias": "champion",
+                "requested_mode": "alias",
+                "resolution_strategy": "alias",
+                "selected_model_version": "9",
+                "selected_run_id": "run-v9",
+            },
+        )
+        mock_live.return_value = stable_df.copy()
+
+        result = detect_drift()
+
+        assert result["reference_resolution_mode_requested"] == "alias"
+        assert result["reference_resolution_mode"] == "alias"
+        assert result["reference_model_version_chosen"] == "9"
+        assert result["reference_alias_requested"] == "champion"
+        assert result["reference_resolution_warning"] is None
+
+    @patch("training.detect_drift.get_live_data")
+    @patch("training.detect_drift.get_reference_data")
+    def test_reference_metadata_fields_when_alias_falls_back_to_stage(
+        self, mock_reference, mock_live
+    ):
+        stable_df = pd.DataFrame(
+            {
+                "velocity_24h": np.arange(1000, dtype=float),
+                "amount_to_avg_ratio_30d": np.arange(1000, dtype=float) * 0.5,
+                "balance_volatility_z_score": np.arange(1000, dtype=float) - 250.0,
+            }
+        )
+        mock_reference.return_value = (
+            stable_df,
+            {
+                "requested_alias": "champion",
+                "requested_mode": "alias",
+                "resolution_strategy": "production_stage",
+                "selected_model_version": "7",
+                "selected_run_id": "run-v7",
+                "resolution_warning": "alias_not_found_fallback",
+            },
+        )
+        mock_live.return_value = stable_df.copy()
+
+        result = detect_drift()
+
+        assert result["reference_resolution_mode_requested"] == "alias"
+        assert result["reference_resolution_mode"] == "stage"
+        assert result["reference_model_version_chosen"] == "7"
+        assert result["reference_alias_requested"] == "champion"
+        assert result["reference_resolution_warning"] == "alias_not_found_fallback"
+
+    @patch("training.detect_drift.get_live_data")
+    @patch("training.detect_drift.get_reference_data")
+    def test_reference_metadata_fields_when_no_reference_available(
+        self, mock_reference, mock_live
+    ):
+        mock_reference.return_value = (
+            None,
+            {
+                "requested_alias": "champion",
+                "requested_mode": "alias",
+                "resolution_warning": "no_reference_versions_available",
+            },
+        )
+        mock_live.return_value = pd.DataFrame()
+
+        result = detect_drift()
+
+        assert result["reference_resolution_mode_requested"] == "alias"
+        assert result["reference_resolution_mode"] == "none"
+        assert result["reference_model_version_chosen"] is None
+        assert result["reference_alias_requested"] == "champion"
+        assert (
+            result["reference_resolution_warning"] == "no_reference_versions_available"
+        )
+
 
 class TestDetectDrift:
     """Tests for detect_drift function."""
@@ -727,6 +822,7 @@ class TestDetectDrift:
         assert result["error"] == result["error_message"]
         assert result["resolution_mode"] == DriftResolutionMode.NONE.value
         assert result["reference_model_version"] is None
+        assert result["reference_model_version_chosen"] is None
 
     @patch("training.detect_drift.get_reference_data")
     @patch("training.detect_drift.get_live_data")
@@ -754,6 +850,7 @@ class TestDetectDrift:
         )
         assert result["resolution_mode"] == DriftResolutionMode.NONE.value
         assert result["reference_model_version"] is None
+        assert result["reference_model_version_chosen"] is None
 
     @patch("training.detect_drift.get_reference_data")
     @patch("training.detect_drift.get_live_data")
@@ -794,6 +891,7 @@ class TestDetectDrift:
             DriftResolutionMode.NONE.value,
         }
         assert result["reference_model_version"] is None
+        assert result["reference_model_version_chosen"] is None
 
     @patch("training.detect_drift.get_reference_data")
     @patch("training.detect_drift.get_live_data")
@@ -823,6 +921,7 @@ class TestDetectDrift:
         assert result["error"] is None
         assert result["resolution_mode"] == DriftResolutionMode.ALIAS.value
         assert result["reference_model_version"] == "9"
+        assert result["reference_model_version_chosen"] == "9"
 
     @patch("training.detect_drift.get_reference_data")
     @patch("training.detect_drift.get_live_data")
@@ -958,6 +1057,13 @@ class TestDetectDrift:
                 result["reference_model_version"]
                 == scenario["expected_reference_version"]
             ), scenario["name"]
+            assert (
+                result["reference_model_version_chosen"]
+                == scenario["expected_reference_version"]
+            ), scenario["name"]
+            assert result["reference_resolution_mode"] == result["resolution_mode"], (
+                scenario["name"]
+            )
             assert set(result["reference_resolution"].keys()) == (
                 expected_reference_resolution_keys
             ), scenario["name"]
@@ -988,6 +1094,10 @@ class TestDetectDrift:
                     result["reference_model_version"]
                     == result["reference_resolution"]["selected_model_version"]
                 ), scenario["name"]
+            assert (
+                result["reference_model_version_chosen"]
+                == result["reference_model_version"]
+            ), scenario["name"]
             if result["error_message"] is not None:
                 assert len(result["error_message"]) <= MAX_DRIFT_ERROR_MESSAGE_LENGTH, (
                     scenario["name"]
@@ -1036,6 +1146,8 @@ class TestDetectDrift:
         assert result["error"] == result["error_message"]
         assert result["resolution_mode"] == DriftResolutionMode.STAGE.value
         assert result["reference_model_version"] == "9"
+        assert result["reference_model_version_chosen"] == "9"
+        assert result["reference_resolution_mode"] == DriftResolutionMode.STAGE.value
 
     def test_drift_error_contract_maps_legacy_alias_error_codes(self):
         legacy = {
@@ -1056,6 +1168,8 @@ class TestDetectDrift:
         assert result["error"] == "Insufficient reference data"
         assert result["resolution_mode"] == DriftResolutionMode.LATEST.value
         assert result["reference_model_version"] == "11"
+        assert result["reference_model_version_chosen"] == "11"
+        assert result["reference_resolution_mode"] == DriftResolutionMode.LATEST.value
 
     @pytest.mark.parametrize(
         ("raw_mode", "expected_mode"),
@@ -1094,3 +1208,4 @@ class TestDetectDrift:
         result = detect_drift()
 
         assert result["resolution_mode"] == expected_mode
+        assert result["reference_resolution_mode"] == expected_mode

--- a/python/tests/test_model_manager_defaults.py
+++ b/python/tests/test_model_manager_defaults.py
@@ -116,6 +116,7 @@ def test_ml_health_summary_is_stable_and_bounded():
         "drift",
         "feature_coverage",
         "config",
+        "warnings",
         "status",
         "state",
         "active_model_version",
@@ -154,6 +155,7 @@ def test_ml_health_summary_is_stable_and_bounded():
     }
 
     assert isinstance(health["state"], str)
+    assert isinstance(health["warnings"], list)
     assert health["status"] in OPERABILITY_STATUSES
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
@@ -204,7 +206,8 @@ def test_ml_health_summary_is_stable_and_bounded():
     assert all(
         not isinstance(value, list | tuple | set)
         for key, value in health.items()
-        if key not in {"config", "model", "benchmark", "drift", "feature_coverage"}
+        if key
+        not in {"config", "model", "benchmark", "drift", "feature_coverage", "warnings"}
     )
 
 
@@ -293,7 +296,8 @@ def test_ml_health_summary_rebuilds_canonical_shape_when_payload_incomplete():
     assert all(
         not isinstance(value, list | tuple | set)
         for key, value in health.items()
-        if key not in {"model", "benchmark", "drift", "feature_coverage", "config"}
+        if key
+        not in {"model", "benchmark", "drift", "feature_coverage", "config", "warnings"}
     )
 
 

--- a/python/tests/test_model_manager_defaults.py
+++ b/python/tests/test_model_manager_defaults.py
@@ -5,7 +5,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from forecast.model_manager import ModelManager
-from training.reason_codes import MODEL_MANAGER_BASELINE_DIAGNOSTIC_KEYS
+from training.reason_codes import (
+    MODEL_MANAGER_BASELINE_DIAGNOSTIC_KEYS,
+    OPERABILITY_STATUSES,
+)
 
 
 def _fresh_manager() -> ModelManager:
@@ -113,6 +116,7 @@ def test_ml_health_summary_is_stable_and_bounded():
         "drift",
         "feature_coverage",
         "config",
+        "status",
         "state",
         "active_model_version",
         "last_reload_status",
@@ -150,6 +154,7 @@ def test_ml_health_summary_is_stable_and_bounded():
     }
 
     assert isinstance(health["state"], str)
+    assert health["status"] in OPERABILITY_STATUSES
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
     assert health["last_reload_ts"] is None or isinstance(
@@ -269,6 +274,7 @@ def test_ml_health_summary_rebuilds_canonical_shape_when_payload_incomplete():
         "last_reload_ts",
         "schema_mismatch_detected",
     }
+    assert health["status"] in OPERABILITY_STATUSES
     assert set(health["benchmark"].keys()) == {"enabled", "last_status", "last_run_ts"}
     assert set(health["drift"].keys()) == {
         "reference_resolution_mode",

--- a/python/tests/test_obs_contract_compatibility.py
+++ b/python/tests/test_obs_contract_compatibility.py
@@ -21,6 +21,7 @@ ML_HEALTH_REQUIRED_KEYS = {
     "drift",
     "feature_coverage",
     "config",
+    "status",
     "state",
     "active_model_version",
     "last_reload_status",
@@ -114,6 +115,7 @@ def _assert_ml_health_contract(health: dict) -> None:
     assert set(health["config"].keys()) == ML_HEALTH_CONFIG_KEYS
 
     assert isinstance(health["state"], str)
+    assert health["status"] in {"success", "failure", "unknown", "not_run"}
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
     assert isinstance(health["schema_mismatch_detected"], bool)

--- a/python/tests/test_obs_contract_compatibility.py
+++ b/python/tests/test_obs_contract_compatibility.py
@@ -70,6 +70,11 @@ DRIFT_REQUIRED_KEYS = {
     "alerts",
     "reference_resolution",
     "reference_model_version",
+    "reference_resolution_mode_requested",
+    "reference_resolution_mode",
+    "reference_model_version_chosen",
+    "reference_alias_requested",
+    "reference_resolution_warning",
 }
 DRIFT_OPTIONAL_KEYS = {"error"}
 DRIFT_REFERENCE_RESOLUTION_KEYS = {
@@ -203,7 +208,17 @@ def _assert_drift_contract(result: dict) -> None:
         result["error_message"], max_len=MAX_DRIFT_ERROR_MESSAGE_LENGTH
     )
     _assert_bounded_optional_str(result["reference_model_version"], max_len=64)
+    _assert_bounded_optional_str(result["reference_model_version_chosen"], max_len=64)
+    _assert_bounded_optional_str(result["reference_alias_requested"], max_len=64)
+    _assert_bounded_optional_str(result["reference_resolution_warning"], max_len=64)
     assert result["resolution_mode"] in {"alias", "stage", "latest", "none"}
+    assert result["reference_resolution_mode"] == result["resolution_mode"]
+    assert result["reference_resolution_mode_requested"] in {
+        "alias",
+        "stage",
+        "latest",
+        "none",
+    }
 
     reference_resolution = result["reference_resolution"]
     assert isinstance(reference_resolution, dict)
@@ -229,6 +244,7 @@ def _assert_drift_contract(result: dict) -> None:
             result["reference_model_version"]
             == reference_resolution["selected_model_version"]
         )
+    assert result["reference_model_version_chosen"] == result["reference_model_version"]
 
     for feature_result in result["features"].values():
         assert "psi" in feature_result

--- a/python/tests/test_obs_contract_compatibility.py
+++ b/python/tests/test_obs_contract_compatibility.py
@@ -21,6 +21,7 @@ ML_HEALTH_REQUIRED_KEYS = {
     "drift",
     "feature_coverage",
     "config",
+    "warnings",
     "status",
     "state",
     "active_model_version",
@@ -115,6 +116,16 @@ def _assert_ml_health_contract(health: dict) -> None:
     assert set(health["config"].keys()) == ML_HEALTH_CONFIG_KEYS
 
     assert isinstance(health["state"], str)
+    assert isinstance(health["warnings"], list)
+    assert len(health["warnings"]) <= 4
+    assert set(health["warnings"]).issubset(
+        {
+            "schema_mismatch_detected",
+            "reload_failed_using_last_known_good",
+            "feature_coverage_below_threshold",
+            "drift_reference_unavailable",
+        }
+    )
     assert health["status"] in {"success", "failure", "unknown", "not_run"}
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
@@ -160,7 +171,14 @@ def _assert_ml_health_contract(health: dict) -> None:
     assert all(isinstance(value, bool) for value in health["config"].values())
 
     for key, value in health.items():
-        if key in {"model", "benchmark", "drift", "feature_coverage", "config"}:
+        if key in {
+            "model",
+            "benchmark",
+            "drift",
+            "feature_coverage",
+            "config",
+            "warnings",
+        }:
             continue
         assert not isinstance(value, dict | list | tuple | set)
 

--- a/python/tests/test_obs_contract_compatibility_v6.py
+++ b/python/tests/test_obs_contract_compatibility_v6.py
@@ -1,0 +1,147 @@
+"""Compatibility guards for v6 diagnostics/drift operability contract refinements."""
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+from forecast.model_manager import ModelManager
+from training.detect_drift import detect_drift
+
+
+def _fresh_manager() -> ModelManager:
+    ModelManager._instance = None
+    return ModelManager()
+
+
+def _stable_frame(size: int = 1000) -> pd.DataFrame:
+    base = np.arange(size, dtype=float)
+    return pd.DataFrame(
+        {
+            "velocity_24h": base,
+            "amount_to_avg_ratio_30d": base * 0.5,
+            "balance_volatility_z_score": base - 250.0,
+        }
+    )
+
+
+def test_v6_diagnostics_and_ml_health_contract_guard_fields_and_bounds():
+    manager = _fresh_manager()
+    diagnostics = manager.get_diagnostics()
+    health = diagnostics["ml_health"]
+
+    assert {"status", "warnings", "last_reload_status", "last_reload_ts"}.issubset(
+        diagnostics.keys()
+    )
+    assert {
+        "benchmark_last_run_ts",
+        "feature_coverage_warning_last_seen_ts",
+    }.issubset(diagnostics.keys())
+    assert diagnostics["status"] in {"success", "failure", "unknown", "not_run"}
+    assert diagnostics["last_reload_status"] in {"idle", "success", "failed"}
+    assert diagnostics["benchmark_last_status"] in {
+        None,
+        "skipped_disabled",
+        "skipped_sampled_out",
+        "success",
+        "failed",
+        "unknown",
+    }
+
+    assert {
+        "status",
+        "warnings",
+        "drift_resolution_mode",
+        "drift_last_computed_ts",
+    }.issubset(health.keys())
+    assert health["status"] in {"success", "failure", "unknown", "not_run"}
+    assert isinstance(health["warnings"], list)
+    assert len(health["warnings"]) <= 4
+    assert set(health["warnings"]).issubset(
+        {
+            "schema_mismatch_detected",
+            "reload_failed_using_last_known_good",
+            "feature_coverage_below_threshold",
+            "drift_reference_unavailable",
+        }
+    )
+
+    for ts_key in (
+        "last_reload_ts",
+        "benchmark_last_run_ts",
+        "feature_coverage_warning_last_seen_ts",
+    ):
+        assert ts_key.endswith("_ts")
+        assert diagnostics[ts_key] is None or isinstance(diagnostics[ts_key], float)
+
+    for ts_key in (
+        "last_reload_ts",
+        "feature_coverage_last_seen_ts",
+        "drift_last_computed_ts",
+    ):
+        assert ts_key.endswith("_ts")
+        assert health[ts_key] is None or isinstance(health[ts_key], float)
+
+
+@patch("training.detect_drift.get_reference_data")
+@patch("training.detect_drift.get_live_data")
+def test_v6_drift_contract_guard_reference_metadata_fields_and_bounds(
+    mock_live, mock_ref
+):
+    stable_df = _stable_frame()
+    mock_ref.return_value = (
+        stable_df,
+        {
+            "requested_alias": "champion",
+            "requested_mode": "alias",
+            "resolution_strategy": "production_stage",
+            "selected_model_version": "7",
+            "selected_run_id": "run-v7",
+            "resolution_warning": "alias_not_found_fallback",
+        },
+    )
+    mock_live.return_value = stable_df.copy()
+
+    result = detect_drift()
+
+    assert {
+        "timestamp",
+        "resolution_mode",
+        "reference_resolution_mode_requested",
+        "reference_resolution_mode",
+        "reference_model_version",
+        "reference_model_version_chosen",
+        "reference_alias_requested",
+        "reference_resolution_warning",
+        "reference_resolution",
+    }.issubset(result.keys())
+
+    assert isinstance(result["timestamp"], str)
+    assert result["resolution_mode"] in {"alias", "stage", "latest", "none"}
+    assert result["reference_resolution_mode"] == result["resolution_mode"]
+    assert result["reference_resolution_mode_requested"] in {
+        "alias",
+        "stage",
+        "latest",
+        "none",
+    }
+    assert result["reference_model_version"] == result["reference_model_version_chosen"]
+    assert result["reference_alias_requested"] == "champion"
+    assert result["reference_resolution_warning"] in {
+        None,
+        "alias_not_found_fallback",
+        "alias_ambiguous_selected_highest",
+        "stage_fallback_used",
+        "latest_fallback_used",
+        "no_reference_versions_available",
+    }
+
+    assert result["reference_alias_requested"] is None or (
+        len(result["reference_alias_requested"]) <= 64
+    )
+    assert result["reference_model_version_chosen"] is None or (
+        len(result["reference_model_version_chosen"]) <= 64
+    )
+    assert result["reference_resolution_warning"] is None or (
+        len(result["reference_resolution_warning"]) <= 64
+    )

--- a/python/tests/test_obs_payload_shapes_golden.py
+++ b/python/tests/test_obs_payload_shapes_golden.py
@@ -47,6 +47,7 @@ def test_ml_health_payload_golden_shape_and_bounds():
         "drift",
         "feature_coverage",
         "config",
+        "warnings",
         "status",
         "state",
         "active_model_version",
@@ -74,6 +75,7 @@ def test_ml_health_payload_golden_shape_and_bounds():
         "last_error_code",
     }
     assert set(health["feature_coverage"].keys()) == {"last_ratio", "below_threshold"}
+    assert isinstance(health["warnings"], list)
     assert health["status"] in {"success", "failure", "unknown", "not_run"}
     assert health["state"] in {"idle", "loading", "ready", "failed"}
     assert len(health["active_model_version"]) <= 64

--- a/python/tests/test_obs_payload_shapes_golden.py
+++ b/python/tests/test_obs_payload_shapes_golden.py
@@ -47,6 +47,7 @@ def test_ml_health_payload_golden_shape_and_bounds():
         "drift",
         "feature_coverage",
         "config",
+        "status",
         "state",
         "active_model_version",
         "last_reload_status",
@@ -73,6 +74,7 @@ def test_ml_health_payload_golden_shape_and_bounds():
         "last_error_code",
     }
     assert set(health["feature_coverage"].keys()) == {"last_ratio", "below_threshold"}
+    assert health["status"] in {"success", "failure", "unknown", "not_run"}
     assert health["state"] in {"idle", "loading", "ready", "failed"}
     assert len(health["active_model_version"]) <= 64
     assert len(health["last_reload_status"]) <= 32

--- a/python/tests/test_obs_payload_shapes_golden.py
+++ b/python/tests/test_obs_payload_shapes_golden.py
@@ -153,8 +153,14 @@ def test_detect_drift_payload_golden_shape_and_bounds(mock_live, mock_ref):
         "alerts",
         "reference_resolution",
         "reference_model_version",
+        "reference_resolution_mode_requested",
+        "reference_resolution_mode",
+        "reference_model_version_chosen",
+        "reference_alias_requested",
+        "reference_resolution_warning",
     }
     assert result["resolution_mode"] in {"alias", "stage", "latest", "none"}
+    assert result["reference_resolution_mode"] == result["resolution_mode"]
     assert isinstance(result["features"], dict)
     assert len(result["features"]) <= len(MONITORED_FEATURES)
     assert len(result["drifted_features"]) <= len(MONITORED_FEATURES)
@@ -165,6 +171,9 @@ def test_detect_drift_payload_golden_shape_and_bounds(mock_live, mock_ref):
     assert result["error"] is None
     assert result["reference_model_version"] is None or (
         len(result["reference_model_version"]) <= 64
+    )
+    assert result["reference_model_version_chosen"] is None or (
+        len(result["reference_model_version_chosen"]) <= 64
     )
 
     for feature_name, feature_result in result["features"].items():
@@ -210,6 +219,11 @@ def test_detect_drift_error_payload_golden_shape_and_bounds(mock_live, mock_ref)
         "alerts",
         "reference_resolution",
         "reference_model_version",
+        "reference_resolution_mode_requested",
+        "reference_resolution_mode",
+        "reference_model_version_chosen",
+        "reference_alias_requested",
+        "reference_resolution_warning",
         "error",
     }
     assert result["error_code"] == DriftErrorCode.NO_REFERENCE_DATA.value

--- a/python/tests/test_obs_status_timestamp_consistency.py
+++ b/python/tests/test_obs_status_timestamp_consistency.py
@@ -1,0 +1,74 @@
+"""Guardrails for canonical status and timestamp semantics in diagnostics payloads."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from forecast.model_manager import ModelManager
+from training.reason_codes import OPERABILITY_STATUSES, ModelManagerState
+
+
+def _fresh_manager() -> ModelManager:
+    ModelManager._instance = None
+    return ModelManager()
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_status"),
+    [
+        (ModelManagerState.IDLE.value, "not_run"),
+        (ModelManagerState.LOADING.value, "unknown"),
+        (ModelManagerState.READY.value, "success"),
+        (ModelManagerState.FAILED.value, "failure"),
+    ],
+)
+def test_diagnostics_and_ml_health_status_are_canonical(state, expected_status):
+    manager = _fresh_manager()
+    manager._state = state
+
+    diagnostics = manager.get_diagnostics()
+
+    assert diagnostics["status"] == expected_status
+    assert diagnostics["status"] in OPERABILITY_STATUSES
+    assert diagnostics["ml_health"]["status"] == expected_status
+
+
+def test_optional_timestamp_fields_use_explicit_nulls_when_invalid():
+    manager = _fresh_manager()
+    manager._bundle = SimpleNamespace(
+        model=object(),
+        version="v1",
+        source="mlflow",
+        required_features=[],
+        last_reload_ts="not-a-float",
+    )
+    manager._benchmark_last_run_ts = "not-a-float"
+    manager._feature_coverage_warning_last_seen_ts = "not-a-float"
+
+    diagnostics = manager.get_diagnostics()
+
+    assert diagnostics["last_reload_ts"] is None
+    assert diagnostics["benchmark_last_run_ts"] is None
+    assert diagnostics["feature_coverage_warning_last_seen_ts"] is None
+
+    health = diagnostics["ml_health"]
+    assert "last_reload_ts" in health and health["last_reload_ts"] is None
+    assert "feature_coverage_last_seen_ts" in health
+    assert health["feature_coverage_last_seen_ts"] is None
+
+
+def test_unknown_benchmark_status_is_normalized_to_bounded_code():
+    manager = _fresh_manager()
+    manager._benchmark_last_status = "benchmark failed because dependency x timed out"
+
+    diagnostics = manager.get_diagnostics()
+
+    assert diagnostics["benchmark_last_status"] == "unknown"
+    assert diagnostics["benchmark_last_status"] in {
+        "skipped_disabled",
+        "skipped_sampled_out",
+        "success",
+        "failed",
+        "unknown",
+    }
+    assert diagnostics["ml_health"]["benchmark_status"] == "unknown"

--- a/python/tests/test_obs_warnings_summary.py
+++ b/python/tests/test_obs_warnings_summary.py
@@ -1,0 +1,71 @@
+"""Contract guards for bounded operator warning summaries."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from forecast.model_manager import ModelManager
+from training.reason_codes import DIAGNOSTICS_WARNING_CODES
+
+
+def _fresh_manager() -> ModelManager:
+    ModelManager._instance = None
+    return ModelManager()
+
+
+def test_warnings_field_is_always_present_with_bounded_values():
+    manager = _fresh_manager()
+
+    diagnostics = manager.get_diagnostics()
+
+    assert diagnostics["warnings"] == []
+    assert diagnostics["ml_health"]["warnings"] == []
+    assert set(diagnostics["warnings"]).issubset(DIAGNOSTICS_WARNING_CODES)
+
+
+def test_warnings_include_expected_codes_without_verbose_strings():
+    manager = _fresh_manager()
+    manager._schema_mismatch_detected = True
+    manager._model_source = "fallback"
+    manager.update_feature_coverage_warning(active=True, observed_ts=111.0)
+
+    diagnostics = manager.get_diagnostics()
+
+    assert set(diagnostics["warnings"]).issubset(DIAGNOSTICS_WARNING_CODES)
+    assert {
+        "schema_mismatch_detected",
+        "reload_failed_using_last_known_good",
+        "feature_coverage_below_threshold",
+    }.issubset(set(diagnostics["warnings"]))
+    assert diagnostics["ml_health"]["warnings"] == diagnostics["warnings"]
+
+
+def test_warnings_capture_drift_reference_unavailable_when_mode_is_none():
+    manager = _fresh_manager()
+    mock_cache = SimpleNamespace(
+        _cache=SimpleNamespace(
+            computed_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            result={"resolution_mode": "none"},
+        )
+    )
+
+    with patch("forecast.drift_cache.get_drift_cache", return_value=mock_cache):
+        diagnostics = manager.get_diagnostics()
+
+    assert "drift_reference_unavailable" in diagnostics["warnings"]
+    assert set(diagnostics["warnings"]).issubset(DIAGNOSTICS_WARNING_CODES)
+
+
+def test_invalid_warning_strings_are_filtered_from_ml_health_summary():
+    manager = _fresh_manager()
+    diagnostics = manager.get_diagnostics()
+    diagnostics["warnings"] = [
+        "freeform operator message with verbose details that should be dropped",
+        "feature_coverage_below_threshold",
+        "",
+        None,
+    ]
+
+    health = manager._build_ml_health_summary(diagnostics)
+
+    assert health["warnings"] == ["feature_coverage_below_threshold"]

--- a/python/tests/test_operability_contract_shapes.py
+++ b/python/tests/test_operability_contract_shapes.py
@@ -51,6 +51,7 @@ def test_ml_health_contract_shape_and_bounds():
         "drift",
         "feature_coverage",
         "config",
+        "status",
         "state",
         "active_model_version",
         "last_reload_status",
@@ -83,6 +84,7 @@ def test_ml_health_contract_shape_and_bounds():
         "last_error_code",
     }
     assert set(health["feature_coverage"].keys()) == {"last_ratio", "below_threshold"}
+    assert health["status"] in {"success", "failure", "unknown", "not_run"}
     assert isinstance(health["model"]["state"], str)
     assert isinstance(health["model"]["active_model_version"], str)
     assert isinstance(health["model"]["last_reload_status"], str)

--- a/python/tests/test_operability_contract_shapes.py
+++ b/python/tests/test_operability_contract_shapes.py
@@ -168,9 +168,16 @@ def test_drift_contract_shape_and_bounds(mock_live, mock_ref):
         "alerts",
         "reference_resolution",
         "reference_model_version",
+        "reference_resolution_mode_requested",
+        "reference_resolution_mode",
+        "reference_model_version_chosen",
+        "reference_alias_requested",
+        "reference_resolution_warning",
     }
     assert result["resolution_mode"] in {"alias", "stage", "latest", "none"}
+    assert result["reference_resolution_mode"] == result["resolution_mode"]
     assert result["reference_model_version"] == "9"
+    assert result["reference_model_version_chosen"] == "9"
     assert len(result["features"]) <= len(MONITORED_FEATURES)
     assert len(result["drifted_features"]) <= len(MONITORED_FEATURES)
     assert len(result["alerts"]) <= len(MONITORED_FEATURES)
@@ -221,6 +228,11 @@ def test_drift_error_contract_shape_and_bounds(mock_live, mock_ref):
         "alerts",
         "reference_resolution",
         "reference_model_version",
+        "reference_resolution_mode_requested",
+        "reference_resolution_mode",
+        "reference_model_version_chosen",
+        "reference_alias_requested",
+        "reference_resolution_warning",
         "error",
     }
     assert result["error_code"] == DriftErrorCode.NO_REFERENCE_DATA.value

--- a/python/tests/test_operability_contract_shapes.py
+++ b/python/tests/test_operability_contract_shapes.py
@@ -51,6 +51,7 @@ def test_ml_health_contract_shape_and_bounds():
         "drift",
         "feature_coverage",
         "config",
+        "warnings",
         "status",
         "state",
         "active_model_version",
@@ -84,6 +85,7 @@ def test_ml_health_contract_shape_and_bounds():
         "last_error_code",
     }
     assert set(health["feature_coverage"].keys()) == {"last_ratio", "below_threshold"}
+    assert isinstance(health["warnings"], list)
     assert health["status"] in {"success", "failure", "unknown", "not_run"}
     assert isinstance(health["model"]["state"], str)
     assert isinstance(health["model"]["active_model_version"], str)
@@ -120,7 +122,9 @@ def test_ml_health_contract_shape_and_bounds():
         health["drift_last_error_code"] is None
         or len(health["drift_last_error_code"]) <= 64
     )
-    for value in health.values():
+    for key, value in health.items():
+        if key == "warnings":
+            continue
         assert not isinstance(value, list | tuple | set)
 
 

--- a/python/tests/test_reason_codes.py
+++ b/python/tests/test_reason_codes.py
@@ -11,7 +11,9 @@ from training.reason_codes import (
     DIAGNOSTIC_KEY_SCHEMA_MISMATCH_DETECTED,
     DIAGNOSTIC_KEY_STATE,
     DIAGNOSTIC_KEY_STATUS,
+    DIAGNOSTIC_KEY_WARNINGS,
     DIAGNOSTICS_DEGRADED_REASONS,
+    DIAGNOSTICS_WARNING_CODES,
     DRIFT_ERROR_CODES,
     DRIFT_FALLBACK_REASONS,
     DRIFT_RESOLUTION_MODES,
@@ -65,6 +67,12 @@ def test_reason_code_sets_are_bounded_and_stable():
         "schema_mismatch",
         "feature_coverage_warning",
     }
+    assert DIAGNOSTICS_WARNING_CODES == {
+        "schema_mismatch_detected",
+        "reload_failed_using_last_known_good",
+        "feature_coverage_below_threshold",
+        "drift_reference_unavailable",
+    }
     assert MODEL_MANAGER_STATES == {"idle", "loading", "ready", "failed"}
     assert RELOAD_STATUSES == {"idle", "success", "failed"}
     assert RESUME_VALIDATION_REASONS == {
@@ -96,6 +104,7 @@ def test_mlflow_reason_metadata_keys_stable():
 def test_model_manager_diagnostics_metadata_keys_stable():
     assert DIAGNOSTIC_KEY_STATE == "state"
     assert DIAGNOSTIC_KEY_STATUS == "status"
+    assert DIAGNOSTIC_KEY_WARNINGS == "warnings"
     assert DIAGNOSTIC_KEY_ACTIVE_MODEL_VERSION == "active_model_version"
     assert DIAGNOSTIC_KEY_LAST_RELOAD_STATUS == "last_reload_status"
     assert DIAGNOSTIC_KEY_SCHEMA_MISMATCH_DETECTED == "schema_mismatch_detected"

--- a/python/tests/test_reason_codes.py
+++ b/python/tests/test_reason_codes.py
@@ -10,6 +10,7 @@ from training.reason_codes import (
     DIAGNOSTIC_KEY_ML_TRAINING_RUN_ID,
     DIAGNOSTIC_KEY_SCHEMA_MISMATCH_DETECTED,
     DIAGNOSTIC_KEY_STATE,
+    DIAGNOSTIC_KEY_STATUS,
     DIAGNOSTICS_DEGRADED_REASONS,
     DRIFT_ERROR_CODES,
     DRIFT_FALLBACK_REASONS,
@@ -27,6 +28,7 @@ from training.reason_codes import (
     MLFLOW_TAG_TUNING_RESUME_REASON,
     MODEL_MANAGER_BASELINE_DIAGNOSTIC_KEYS,
     MODEL_MANAGER_STATES,
+    OPERABILITY_STATUSES,
     RELOAD_FAILURE_REASONS,
     RELOAD_STATUSES,
     RESUME_VALIDATION_REASONS,
@@ -55,7 +57,9 @@ def test_reason_code_sets_are_bounded_and_stable():
         "skipped_sampled_out",
         "success",
         "failed",
+        "unknown",
     }
+    assert OPERABILITY_STATUSES == {"success", "failure", "unknown", "not_run"}
     assert DIAGNOSTICS_DEGRADED_REASONS == {
         "reload_failed",
         "schema_mismatch",
@@ -91,6 +95,7 @@ def test_mlflow_reason_metadata_keys_stable():
 
 def test_model_manager_diagnostics_metadata_keys_stable():
     assert DIAGNOSTIC_KEY_STATE == "state"
+    assert DIAGNOSTIC_KEY_STATUS == "status"
     assert DIAGNOSTIC_KEY_ACTIVE_MODEL_VERSION == "active_model_version"
     assert DIAGNOSTIC_KEY_LAST_RELOAD_STATUS == "last_reload_status"
     assert DIAGNOSTIC_KEY_SCHEMA_MISMATCH_DETECTED == "schema_mismatch_detected"


### PR DESCRIPTION
#### Summary

* normalize diagnostics status/timestamp semantics
* add bounded warnings summary
* clarify drift reference metadata
* add compatibility tests and docs updates

#### Compatibility

* additive / non-breaking only
* no new dependencies
* no API removals

#### Test plan

.............................................sssssssssssssssssssssssssss [ 16%]
ssssssssssssssssssss.................................................... [ 32%]
........................................................................ [ 48%]
.....................ss................................................. [ 64%]
........................................................................ [ 80%]
......................................................s................. [ 96%]
..................                                                       [100%]
=============================== warnings summary ===============================
python/tests/model/test_calibration_guards.py::TestCalibrationGuards::test_calibration_skipped_insufficient_samples
python/tests/model/test_calibration_guards.py::TestCalibrationGuards::test_calibration_skipped_insufficient_positives
python/tests/model/test_calibration_guards.py::TestCalibrationGuards::test_calibration_skipped_insufficient_negatives
python/tests/model/test_calibration_guards.py::TestCalibrationGuards::test_calibration_success_when_thresholds_met
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/training.py:199: UserWarning: [01:59:10] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    bst.update(dtrain, iteration=i, fobj=obj)

python/tests/model/test_calibration_guards.py: 4 warnings
python/tests/model/test_schema_hash.py: 1 warning
python/tests/test_hyperparameters.py: 4 warnings
python/tests/test_obs_training_identity.py: 1 warning
python/tests/test_train_feature_columns.py: 3 warnings
python/tests/test_train_metrics.py: 6 warnings
python/tests/test_tuning.py: 1 warning
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/mlflow/types/utils.py:452: UserWarning: Hint: Inferred schema contains integer column(s). Integer columns in Python cannot represent missing values. If your input data contains missing values at inference time, it will be encoded as floats and will cause a schema enforcement error. The best way to avoid this problem is to infer the model schema based on a realistic data sample (training dataset) that includes missing values. Alternatively, you can declare integer columns as doubles (float64) whenever these columns may have missing values. See `Handling Integers With Missing Values <https://www.mlflow.org/docs/latest/models.html#handling-integers-with-missing-values>`_ for more details.
    warnings.warn(

python/tests/test_hyperparameters.py::TestHyperparamsLoggedToMlflow::test_hyperparams_logged_to_mlflow
python/tests/test_hyperparameters.py::TestDefaultHyperparamsUnchanged::test_default_hyperparams_unchanged
python/tests/test_train_feature_columns.py::TestTrainModelWithFeatureColumns::test_train_model_logs_feature_columns_param
python/tests/test_train_feature_columns.py::TestTrainModelWithFeatureColumns::test_train_model_logs_feature_columns_artifact
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/training.py:199: UserWarning: [01:59:12] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    bst.update(dtrain, iteration=i, fobj=obj)

python/tests/test_hyperparameters.py::TestEarlyStopping::test_early_stopping_logs_best_iteration
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/callback.py:386: UserWarning: [01:59:12] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    self.starting_round = model.num_boosted_rounds()

python/tests/test_train_feature_columns.py: 1 warning
python/tests/test_train_metrics.py: 15 warnings
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/training.py:199: UserWarning: [01:59:13] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    bst.update(dtrain, iteration=i, fobj=obj)

python/tests/test_train_metrics.py::TestPerformanceMetricsLogging::test_training_time_seconds_logged
python/tests/test_train_metrics.py::TestPerformanceMetricsLogging::test_model_size_bytes_positive_when_logged
python/tests/test_tuning.py::TestTuningStudy::test_disabled_tuning_skipped
python/tests/test_tuning.py::TestSelectedTrialOverride::test_selected_trial_overrides_best
  /Users/jonathan/git/label-lag/.venv/lib/python3.12/site-packages/xgboost/training.py:199: UserWarning: [01:59:14] WARNING: /Users/runner/work/xgboost/xgboost/src/learner.cc:790: 
  Parameters: { "use_label_encoder" } are not used.
  
    bst.update(dtrain, iteration=i, fobj=obj)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
______________ coverage: platform darwin, python 3.12.12-final-0 _______________

Name                                          Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------------
python/src/features/registry.py                  21      2      2      1    87%   65, 76
python/src/features/store.py                     81     59     14      0    23%   21, 26, 33, 42-51, 64-76, 79-81, 85-113, 119-155, 160
python/src/forecast/drift_cache.py               48      5     10      3    86%   30-33, 73, 79
python/src/forecast/model_manager.py            896    136    326     51    82%   89-94, 172->175, 227, 229, 232-233, 303->exit, 306-307, 322, 324->315, 327->335, 331->335, 336-340, 360-361, 420, 458->460, 463, 471->473, 476, 489-504, 516, 522, 540->542, 543, 571->579, 603, 611, 623-627, 646->648, 660, 689->726, 719, 721-724, 1031-1040, 1051-1059, 1182-1183, 1207, 1213, 1234->1258, 1235->1234, 1243-1244, 1252, 1256-1257, 1268->1267, 1275, 1278-1279, 1290->1289, 1303-1304, 1319->1334, 1320->1319, 1332-1333, 1347->1361, 1348->1347, 1355, 1359-1360, 1366-1371, 1379-1381, 1387, 1391, 1397->1404, 1400-1403, 1436, 1525->1524, 1535-1536, 1561-1595, 1609->1608, 1611-1613, 1634-1638, 1660-1662, 1678-1706, 1721, 1735, 1738, 1784-1787
python/src/forecast/service.py                  110     22     22      4    80%   28, 38, 81-83, 87->90, 107-109, 116-117, 155-157, 196-216
python/src/forecast/services.py                 224     52     68      9    76%   42-46, 59-61, 172-173, 315->321, 356-360, 369-376, 420-459, 471-480, 507, 511-512, 516-517, 521-522, 526-527, 548-550
python/src/inference/__init__.py                  5      1      2      1    71%   9
python/src/inference/config.py                   48     27     14      0    34%   26-30, 48-54, 58-61, 65-76
python/src/inference/logging.py                   3      3      0      0     0%   3-7
python/src/inference/server.py                   34     34      6      0     0%   3-64
python/src/inference/service.py                  54     15     10      3    72%   34, 42, 64-65, 71-74, 83-84, 96-97, 103-114
python/src/logging_util.py                       13     13      2      0     0%   3-72
python/src/main.py                               47     47      8      0     0%   3-133
python/src/model/evaluate.py                    140      5     20      3    95%   152, 306->exit, 425-429
python/src/model/loader.py                       98      3     34      2    96%   133->139, 139->144, 235-238
python/src/model/split_strategies.py             75      7     12      4    87%   35, 50-51, 79-80, 118, 126
python/src/model/train.py                       483     47    136     24    88%   54-56, 100-101, 105->114, 109-111, 121, 123, 128, 146-147, 278-283, 305-307, 335, 362->368, 374, 456, 458, 469-470, 472->475, 533->633, 601->605, 800, 812->827, 823, 834->856, 846->856, 852, 875, 974-982, 987-994
python/src/model/tuning.py                      310     59    132     30    77%   76-79, 85, 88, 91-92, 95, 100-101, 116-120, 128-135, 158, 169, 191->194, 358-359, 362->368, 377-378, 384, 386->exit, 397->399, 400-418, 469-474, 484-485, 487->493, 490-491, 514, 536->602, 543->551, 555->602, 596, 599-600, 603, 605, 631, 649->661, 652-660, 672, 675->678, 680, 681->664, 689->730, 727-728
python/src/training/audit.py                     90      3     20      2    95%   38->40, 63, 89-90
python/src/training/config.py                    12      1      0      0    92%   19
python/src/training/crud_client.py              222     58     52     12    72%   52-58, 65->70, 117-118, 126-127, 147-158, 166-171, 176-177, 185-188, 227, 231-232, 242-243, 252-253, 262-263, 280-281, 294-298, 308-311, 324->326, 327, 400, 402, 408-409, 425, 434-439, 446-447, 454, 467, 469, 494-495, 500-501, 513->515, 528-529
python/src/training/detect_drift.py             497     75    188     25    82%   86-92, 221, 300-301, 309, 311, 314-315, 408->412, 412->420, 447, 460, 478-479, 484, 489-491, 504->507, 531, 540, 597->605, 600->602, 603, 668, 674-676, 682-693, 741-742, 796, 829, 853-859, 864-892, 937->955, 1080-1095, 1099
python/src/training/gateway_client.py            19     13      4      0    26%   12-29, 35
python/src/training/gateway_grpc_client.py       76     57     16      0    21%   13-17, 26-31, 44-69, 83-120, 123-155, 158, 174, 185-193
python/src/training/grpc_errors.py                6      4      2      0    25%   13-17
python/src/training/job_queue.py                 30      1      4      1    94%   31
python/src/training/job_store.py                134     15     52     16    83%   31-32, 43-44, 61->exit, 63->exit, 65->exit, 69->exit, 76->exit, 78->exit, 86->exit, 88->exit, 90->exit, 101, 113, 145, 150-151, 167, 184-185, 191, 204, 221
python/src/training/materialize_features.py      26      6      4      1    77%   45-52
python/src/training/optuna_resume.py             74     18     20      7    71%   23, 31, 55, 65, 89-99, 103-106, 122-123, 147->156, 152-154
python/src/training/postgres_job_store.py       137     48     28      7    59%   27, 32, 40-41, 49, 159-166, 175, 190-240, 243-251, 263-280, 283->289, 286-287, 326, 329-344, 347, 391, 394
python/src/training/schemas.py                  311      3      4      0    98%   368-370
python/src/training/server.py                    52     52      4      0     0%   3-102
python/src/training/service.py                  618    304    218     54    49%   75-76, 79-80, 102-103, 111-112, 122, 125-126, 130-133, 141-142, 144->143, 146, 176, 178, 203, 212, 219->exit, 224-233, 237-488, 492-514, 518-577, 591-605, 607->610, 611-635, 640->661, 648-649, 653, 685->704, 726-728, 732-756, 768-783, 785->788, 789-802, 807->825, 815, 819, 826, 832, 838, 853, 884-964, 972-974, 980, 1011-1012, 1041-1045, 1053, 1055, 1064, 1133-1139, 1152-1158, 1165, 1168, 1172, 1181, 1194->1197, 1223, 1227, 1271, 1288->1290, 1303, 1307, 1309, 1323, 1333, 1357, 1359, 1363-1364, 1369, 1376, 1384->exit, 1389-1392, 1401-1419
python/src/training/tuning_startup.py            79      9     18      2    87%   31-35, 44-49, 53-58
python/src/training/worker.py                   220     36     60     16    80%   27, 38, 73-75, 79-82, 117, 129->134, 137-138, 140, 173, 187, 190, 201, 247-260, 276, 290-296, 301-302, 307, 328, 341->346, 351-352
-----------------------------------------------------------------------------------------
TOTAL                                          5536   1240   1522    278    75%

13 files skipped due to complete coverage.
400 passed, 50 skipped, 49 warnings in 26.06s

#### Risk

Low. This is diagnostics/drift contract cleanup, bounded summary surfacing, compatibility testing, and doc alignment.

Closes #399