### PR TITLE
Follow-up operability tranche: ML diagnostics and drift contract polish v8

### DIFF
--- a/docs/inference/model_manager_diagnostics_contract.md
+++ b/docs/inference/model_manager_diagnostics_contract.md
@@ -139,6 +139,12 @@ backward compatibility.
   - `below_threshold`
 - `config`
 - `warnings` (bounded list of warning codes)
+- summary block
+  - `status`
+  - `overall_status`
+  - `degraded`
+  - `has_warnings`
+  - `warning_count`
 
 `ml_health.config` keys (always present, default `false`):
 
@@ -173,6 +179,10 @@ Legacy aliases retained in `ml_health`:
 Additional canonical top-level summary fields in `ml_health`:
 
 - `status`
+- `overall_status` (authoritative alias of `status`)
+- `degraded` (derived from canonical `degraded_reasons` + `overall_status`)
+- `has_warnings` (derived from canonical warnings list)
+- `warning_count` (derived from canonical warnings list length)
 - `warnings`
 
 `ml_health.feature_coverage.last_ratio` semantics:
@@ -222,7 +232,7 @@ Field semantics:
 - `reference_model_version_chosen`: additive alias for selected reference model version.
 - `reference_alias_requested`: requested alias (when configured).
 - `reference_resolution_warning`: bounded optional warning code explaining fallback/ambiguity.
-- `drift_error`: legacy drift code mirror (set when canonical `error_code` is set).
+- `drift_error`: legacy drift code mirror; either canonical `error_code` value or `null`.
 
 `reference_resolution` shape (always present):
 
@@ -238,7 +248,7 @@ Field semantics:
 
 - `psi`: float
 - `status`: `OK` / `WARNING` / `CRITICAL`
-- `drift_error`: string or `null`
+- `drift_error`: canonical error code or `null`
 - `bucketing`: normalized metadata map with bounded keys:
   - `buckettype_requested`
   - `buckettype_used`
@@ -289,7 +299,7 @@ Legacy normalization behavior:
 - Legacy error-code aliases (for example `insufficient_reference_data`,
   `no_reference_model`, `no_live_window`) are normalized into canonical
   `error_code` values.
-- `error_message` is capped at 200 characters.
+- `error_message` is capped at 200 characters and is null when `error_code` is null.
 
 ### Reference Resolution Metadata (Always Present)
 
@@ -306,7 +316,7 @@ Legacy normalization behavior:
 Notes:
 
 - `resolution_mode` is canonical (`alias|stage|latest|none`).
-- `resolution_strategy` may preserve legacy values for compatibility.
+- `resolution_strategy` is canonical and mirrors `resolution_mode`.
 - `alias_candidate_count` is always an integer (default `0`).
 - `alias_ambiguous` is always a boolean (default `false`).
 
@@ -340,6 +350,12 @@ Each `features.<name>.bucketing` map includes:
 - `bucket_mass_ok`
 - `bucket_mass_guardrail_applied`
 - `drift_error`
+
+Bucketing normalization semantics:
+
+- `buckettype_requested` / `buckettype_used`: `bins` / `quantiles` / `null`.
+- `bucketing_fallback_reason`: canonical fallback reason (`tied_quantiles`, `insufficient_bucket_mass`) or `null`.
+- `drift_error`: canonical `error_code` value or `null`.
 
 ## Example Payload
 
@@ -400,6 +416,10 @@ Each `features.<name>.bucketing` map includes:
     },
     "warnings": [],
     "status": "success",
+    "overall_status": "success",
+    "degraded": false,
+    "has_warnings": false,
+    "warning_count": 0,
     "state": "ready",
     "active_model_version": "v17",
     "last_reload_status": "success",

--- a/python/src/forecast/model_manager.py
+++ b/python/src/forecast/model_manager.py
@@ -46,6 +46,7 @@ from training.reason_codes import (
     DIAGNOSTIC_KEY_STATE,
     DIAGNOSTIC_KEY_STATUS,
     DIAGNOSTIC_KEY_WARNINGS,
+    DIAGNOSTICS_DEGRADED_REASONS,
     DIAGNOSTICS_WARNING_CODES,
     MODEL_MANAGER_STATES,
     RELOAD_FAILURE_REASONS,
@@ -162,6 +163,10 @@ class ModelManager:
         "config",
         "warnings",
         "status",
+        "overall_status",
+        "degraded",
+        "has_warnings",
+        "warning_count",
         "state",
         "active_model_version",
         "last_reload_status",
@@ -549,6 +554,30 @@ class ModelManager:
                 break
         return normalized
 
+    @classmethod
+    def _normalize_degraded_reasons(cls, raw_reasons: Any) -> list[str]:
+        if isinstance(raw_reasons, str):
+            candidates: list[Any] = [raw_reasons]
+        elif isinstance(raw_reasons, list | tuple | set):
+            candidates = list(raw_reasons)
+        else:
+            candidates = []
+        normalized: list[str] = []
+        for candidate in candidates:
+            reason = cls._bounded_optional_str(
+                candidate, max_len=cls._MAX_REASON_CODE_LENGTH
+            )
+            if reason is None:
+                continue
+            reason = reason.lower()
+            if reason not in DIAGNOSTICS_DEGRADED_REASONS:
+                continue
+            if reason not in normalized:
+                normalized.append(reason)
+            if len(normalized) >= 4:
+                break
+        return normalized
+
     @staticmethod
     def _normalize_benchmark_last_status(raw_status: Any) -> str | None:
         normalized = ModelManager._bounded_optional_str(raw_status, max_len=32)
@@ -842,6 +871,15 @@ class ModelManager:
                     DiagnosticsWarningCode.DRIFT_REFERENCE_UNAVAILABLE.value,
                 ]
             )
+        degraded_reasons = self._normalize_degraded_reasons(
+            diagnostics_snapshot.get(DIAGNOSTIC_KEY_DEGRADED_REASONS)
+        )
+        has_warnings = bool(warnings)
+        warning_count = len(warnings)
+        degraded = bool(degraded_reasons) or health_status in {
+            OperabilityStatus.FAILURE.value,
+            OperabilityStatus.UNKNOWN.value,
+        }
 
         # Keep legacy scalar aliases for compatibility with existing consumers.
         payload = {
@@ -852,6 +890,10 @@ class ModelManager:
             "config": strict_config,
             "warnings": warnings,
             "status": health_status,
+            "overall_status": health_status,
+            "degraded": degraded,
+            "has_warnings": has_warnings,
+            "warning_count": warning_count,
             "state": model_summary["state"],
             "active_model_version": model_summary["active_model_version"],
             "last_reload_status": model_summary["last_reload_status"],

--- a/python/src/forecast/model_manager.py
+++ b/python/src/forecast/model_manager.py
@@ -46,6 +46,9 @@ from training.reason_codes import (
     DIAGNOSTIC_KEY_STATE,
     DIAGNOSTIC_KEY_STATUS,
     DIAGNOSTIC_KEY_WARNINGS,
+    DIAGNOSTICS_WARNING_CODES,
+    MODEL_MANAGER_STATES,
+    RELOAD_FAILURE_REASONS,
     TRACE_KEY_ML_FEATURE_SCHEMA_HASH,
     TRACE_KEY_ML_MODEL_VERSION,
     TRACE_KEY_ML_TRAINING_RUN_ID,
@@ -143,6 +146,14 @@ class ModelManager:
     _ML_HEALTH_BENCHMARK_KEYS = ("enabled", "last_status", "last_run_ts")
     _ML_HEALTH_DRIFT_KEYS = ("reference_resolution_mode", "last_error_code")
     _ML_HEALTH_FEATURE_COVERAGE_KEYS = ("last_ratio", "below_threshold")
+    _MAX_STATE_LENGTH = 32
+    _MAX_MODEL_VERSION_LENGTH = 64
+    _MAX_MODEL_SOURCE_LENGTH = 16
+    _MAX_RELOAD_STATUS_LENGTH = 32
+    _MAX_REASON_CODE_LENGTH = 64
+    _MAX_LAST_ERROR_LENGTH = 200
+    _MAX_TRAINING_RUN_ID_LENGTH = 128
+    _MAX_SCHEMA_HASH_LENGTH = 128
     _ML_HEALTH_TOP_LEVEL_KEYS = (
         "model",
         "benchmark",
@@ -530,12 +541,7 @@ class ModelManager:
             if warning is None:
                 continue
             warning = warning.lower()
-            if warning not in {
-                DiagnosticsWarningCode.SCHEMA_MISMATCH_DETECTED.value,
-                DiagnosticsWarningCode.RELOAD_FAILED_USING_LAST_KNOWN_GOOD.value,
-                DiagnosticsWarningCode.FEATURE_COVERAGE_BELOW_THRESHOLD.value,
-                DiagnosticsWarningCode.DRIFT_REFERENCE_UNAVAILABLE.value,
-            }:
+            if warning not in DIAGNOSTICS_WARNING_CODES:
                 continue
             if warning not in normalized:
                 normalized.append(warning)
@@ -586,6 +592,41 @@ class ModelManager:
         if state == ModelManagerState.IDLE.value:
             return OperabilityStatus.NOT_RUN.value
         return OperabilityStatus.UNKNOWN.value
+
+    @classmethod
+    def _normalize_model_manager_state(cls, raw_state: Any) -> str:
+        normalized = cls._bounded_optional_str(raw_state, max_len=cls._MAX_STATE_LENGTH)
+        if normalized is None:
+            return ModelManagerState.IDLE.value
+        normalized = normalized.lower()
+        if normalized in MODEL_MANAGER_STATES:
+            return normalized
+        return ModelManagerState.IDLE.value
+
+    @classmethod
+    def _normalize_model_source(cls, raw_source: Any) -> str:
+        normalized = cls._bounded_optional_str(
+            raw_source, max_len=cls._MAX_MODEL_SOURCE_LENGTH
+        )
+        if normalized is None:
+            return "none"
+        normalized = normalized.lower()
+        if normalized in {"mlflow", "fallback", "none"}:
+            return normalized
+        return "none"
+
+    @classmethod
+    def _normalize_reload_failure_reason(cls, raw_reason: Any) -> str:
+        normalized = cls._bounded_optional_str(
+            raw_reason,
+            max_len=cls._MAX_REASON_CODE_LENGTH,
+        )
+        if normalized is None:
+            return ReloadFailureReason.UNKNOWN.value
+        normalized = normalized.lower()
+        if normalized in RELOAD_FAILURE_REASONS:
+            return normalized
+        return ReloadFailureReason.UNKNOWN.value
 
     @staticmethod
     def _bounded_optional_str(value: Any, *, max_len: int) -> str | None:
@@ -731,10 +772,8 @@ class ModelManager:
         strict_config = self._normalize_strict_config(
             diagnostics_snapshot.get(DIAGNOSTIC_KEY_CONFIG)
         )
-        model_state = self._bounded_str(
+        model_state = self._normalize_model_manager_state(
             diagnostics_snapshot.get(DIAGNOSTIC_KEY_STATE),
-            default=ModelManagerState.IDLE.value,
-            max_len=32,
         )
 
         model_summary = {
@@ -742,12 +781,12 @@ class ModelManager:
             "active_model_version": self._bounded_str(
                 diagnostics_snapshot.get(DIAGNOSTIC_KEY_ACTIVE_MODEL_VERSION),
                 default="unknown",
-                max_len=64,
+                max_len=self._MAX_MODEL_VERSION_LENGTH,
             ),
             "last_reload_status": self._bounded_str(
                 diagnostics_snapshot.get(DIAGNOSTIC_KEY_LAST_RELOAD_STATUS),
                 default="idle",
-                max_len=32,
+                max_len=self._MAX_RELOAD_STATUS_LENGTH,
             ),
             "last_reload_ts": self._coerce_float_or_none(
                 diagnostics_snapshot.get(DIAGNOSTIC_KEY_LAST_RELOAD_TS)
@@ -759,9 +798,8 @@ class ModelManager:
 
         benchmark_summary = {
             "enabled": bool(INFERENCE_BENCHMARK_ENABLED),
-            "last_status": self._bounded_optional_str(
+            "last_status": self._normalize_benchmark_last_status(
                 diagnostics_snapshot.get(DIAGNOSTIC_KEY_BENCHMARK_LAST_STATUS),
-                max_len=32,
             ),
             "last_run_ts": self._coerce_float_or_none(
                 diagnostics_snapshot.get(DIAGNOSTIC_KEY_BENCHMARK_LAST_RUN_TS)
@@ -769,7 +807,7 @@ class ModelManager:
         }
 
         feature_coverage_summary = {
-            "last_ratio": self._coerce_ratio_or_none(
+            "last_ratio": self._normalize_feature_coverage_ratio(
                 diagnostics_snapshot.get(DIAGNOSTIC_KEY_FEATURE_COVERAGE_LAST_RATIO)
             ),
             "below_threshold": bool(
@@ -787,7 +825,7 @@ class ModelManager:
             ),
             "last_error_code": self._bounded_optional_str(
                 drift_last_error_code,
-                max_len=64,
+                max_len=self._MAX_REASON_CODE_LENGTH,
             ),
         }
         health_status = self._normalize_operability_status(
@@ -877,15 +915,22 @@ class ModelManager:
         with self._lock:
             bundle = self._resolve_runtime_bundle()
             training_identity = self.training_identity or {}
+            manager_state = self._normalize_model_manager_state(self._state)
+            active_model_version = self._bounded_str(
+                self.model_version,
+                default="unknown",
+                max_len=self._MAX_MODEL_VERSION_LENGTH,
+            )
+            model_source = self._normalize_model_source(self.model_source)
             last_reload_status = (
                 ReloadStatus.SUCCESS.value
-                if self._state == ModelManagerState.READY.value
+                if manager_state == ModelManagerState.READY.value
                 else ReloadStatus.FAILED.value
-                if self._state == ModelManagerState.FAILED.value
+                if manager_state == ModelManagerState.FAILED.value
                 else ReloadStatus.IDLE.value
             )
             degraded_reasons: list[str] = []
-            if self._state == ModelManagerState.FAILED.value:
+            if manager_state == ModelManagerState.FAILED.value:
                 degraded_reasons.append(DiagnosticsDegradedReason.RELOAD_FAILED.value)
             if self.schema_mismatch_detected:
                 degraded_reasons.append(DiagnosticsDegradedReason.SCHEMA_MISMATCH.value)
@@ -896,12 +941,15 @@ class ModelManager:
             diagnostics = {
                 DIAGNOSTIC_KEY_STATUS: self._normalize_operability_status(
                     None,
-                    fallback_state=self._state,
+                    fallback_state=manager_state,
                 ),
-                DIAGNOSTIC_KEY_STATE: self._state,
-                DIAGNOSTIC_KEY_MODEL_VERSION: self.model_version,
-                DIAGNOSTIC_KEY_MODEL_SOURCE: self.model_source,
-                DIAGNOSTIC_KEY_LAST_ERROR: self._last_error,
+                DIAGNOSTIC_KEY_STATE: manager_state,
+                DIAGNOSTIC_KEY_MODEL_VERSION: active_model_version,
+                DIAGNOSTIC_KEY_MODEL_SOURCE: model_source,
+                DIAGNOSTIC_KEY_LAST_ERROR: self._bounded_optional_str(
+                    self._last_error,
+                    max_len=self._MAX_LAST_ERROR_LENGTH,
+                ),
                 DIAGNOSTIC_KEY_SCHEMA_MISMATCH_DETECTED: self.schema_mismatch_detected,
                 DIAGNOSTIC_KEY_CALIBRATOR_LOADED: self.calibrator_loaded,
                 DIAGNOSTIC_KEY_HAS_BUNDLE: bundle is not None,
@@ -912,7 +960,7 @@ class ModelManager:
                 else None,
                 DIAGNOSTIC_KEY_LAST_RELOAD_STATUS: last_reload_status,
                 DIAGNOSTIC_KEY_LAST_RELOAD_REASON: (
-                    self._mlflow_failure_reason
+                    self._normalize_reload_failure_reason(self._mlflow_failure_reason)
                     if last_reload_status == ReloadStatus.FAILED.value
                     else None
                 ),
@@ -923,26 +971,31 @@ class ModelManager:
                     self._normalize_benchmark_last_status(self._benchmark_last_status)
                 ),
                 DIAGNOSTIC_KEY_DEGRADED_REASONS: degraded_reasons,
-                DIAGNOSTIC_KEY_ACTIVE_MODEL_VERSION: self.model_version,
+                DIAGNOSTIC_KEY_ACTIVE_MODEL_VERSION: active_model_version,
                 DIAGNOSTIC_KEY_FEATURE_COVERAGE_WARNING_ACTIVE: (
-                    self._feature_coverage_warning_active
+                    bool(self._feature_coverage_warning_active)
                 ),
                 DIAGNOSTIC_KEY_FEATURE_COVERAGE_LAST_RATIO: (
-                    self._feature_coverage_last_ratio
+                    self._normalize_feature_coverage_ratio(
+                        self._feature_coverage_last_ratio
+                    )
                 ),
                 DIAGNOSTIC_KEY_FEATURE_COVERAGE_WARNING_LAST_SEEN_TS: (
                     self._coerce_float_or_none(
                         self._feature_coverage_warning_last_seen_ts
                     )
                 ),
-                DIAGNOSTIC_KEY_ML_TRAINING_RUN_ID: training_identity.get(
-                    TRAINING_IDENTITY_KEY_MLFLOW_RUN_ID
+                DIAGNOSTIC_KEY_ML_TRAINING_RUN_ID: self._bounded_optional_str(
+                    training_identity.get(TRAINING_IDENTITY_KEY_MLFLOW_RUN_ID),
+                    max_len=self._MAX_TRAINING_RUN_ID_LENGTH,
                 ),
-                DIAGNOSTIC_KEY_ML_MODEL_VERSION: training_identity.get(
-                    TRAINING_IDENTITY_KEY_MODEL_VERSION
+                DIAGNOSTIC_KEY_ML_MODEL_VERSION: self._bounded_optional_str(
+                    training_identity.get(TRAINING_IDENTITY_KEY_MODEL_VERSION),
+                    max_len=self._MAX_MODEL_VERSION_LENGTH,
                 ),
-                DIAGNOSTIC_KEY_ML_FEATURE_SCHEMA_HASH: training_identity.get(
-                    TRAINING_IDENTITY_KEY_FEATURE_SCHEMA_HASH
+                DIAGNOSTIC_KEY_ML_FEATURE_SCHEMA_HASH: self._bounded_optional_str(
+                    training_identity.get(TRAINING_IDENTITY_KEY_FEATURE_SCHEMA_HASH),
+                    max_len=self._MAX_SCHEMA_HASH_LENGTH,
                 ),
                 DIAGNOSTIC_KEY_CONFIG: self._normalize_strict_config(
                     self._effective_strict_config()
@@ -958,9 +1011,9 @@ class ModelManager:
                     else None,
                     DiagnosticsWarningCode.RELOAD_FAILED_USING_LAST_KNOWN_GOOD.value
                     if (
-                        self.model_source == "fallback"
+                        model_source == "fallback"
                         or (
-                            self._state == ModelManagerState.FAILED.value
+                            manager_state == ModelManagerState.FAILED.value
                             and bundle is not None
                         )
                     )

--- a/python/src/training/detect_drift.py
+++ b/python/src/training/detect_drift.py
@@ -19,9 +19,13 @@ import pandas as pd
 from training.crud_client import get_crud_client
 from training.reason_codes import (
     DRIFT_ERROR_CODES,
+    DRIFT_FALLBACK_REASONS,
+    DRIFT_REFERENCE_RESOLUTION_WARNING_CODES,
     DRIFT_RESOLUTION_MODES,
     DriftErrorCode,
     DriftFallbackReason,
+    DriftFeatureStatus,
+    DriftReferenceResolutionWarning,
     DriftResolutionMode,
 )
 
@@ -115,16 +119,8 @@ MAX_DRIFT_REFERENCE_RUN_ID_LENGTH = MAX_REFERENCE_RUN_ID_LENGTH
 MAX_DRIFT_REFERENCE_ALIAS_LENGTH = MAX_REFERENCE_METADATA_TEXT_LENGTH
 MAX_DRIFT_BUCKETTYPE_LENGTH = 24
 MAX_DRIFT_BREAKPOINTS = MAX_BREAKPOINTS_COUNT
+DRIFT_BUCKET_TYPES = frozenset({"bins", "quantiles"})
 MAX_REFERENCE_RESOLUTION_WARNING_LENGTH = 64
-REFERENCE_RESOLUTION_WARNING_CODES = frozenset(
-    {
-        "alias_not_found_fallback",
-        "alias_ambiguous_selected_highest",
-        "stage_fallback_used",
-        "latest_fallback_used",
-        "no_reference_versions_available",
-    }
-)
 _DEFAULT_DRIFT_ERROR_MESSAGES = {
     DriftErrorCode.NO_REFERENCE_DATA.value: "No reference data available",
     DriftErrorCode.INSUFFICIENT_REFERENCE_SAMPLES.value: (
@@ -148,6 +144,13 @@ _LEGACY_DRIFT_ERROR_CODE_ALIASES = {
 _LEGACY_RESOLUTION_MODE_ALIASES = {
     "production_stage": DriftResolutionMode.STAGE.value,
     "latest_version": DriftResolutionMode.LATEST.value,
+}
+_LEGACY_REFERENCE_RESOLUTION_WARNING_CODE_ALIASES = {
+    "alias_missing_fallback": (
+        DriftReferenceResolutionWarning.ALIAS_NOT_FOUND_FALLBACK.value
+    ),
+    "fallback_stage_used": DriftReferenceResolutionWarning.STAGE_FALLBACK_USED.value,
+    "fallback_latest_used": DriftReferenceResolutionWarning.LATEST_FALLBACK_USED.value,
 }
 MAX_DRIFT_ERROR_CODE_LENGTH = 64
 _REFERENCE_RESOLUTION_METADATA_KEYS = (
@@ -340,7 +343,9 @@ def _select_reference_model_version(
     }
 
     if not versions:
-        metadata["resolution_warning"] = "no_reference_versions_available"
+        metadata["resolution_warning"] = (
+            DriftReferenceResolutionWarning.NO_REFERENCE_VERSIONS_AVAILABLE.value
+        )
         return None, metadata
 
     normalized_alias = str(alias_name or "").strip().lstrip("@")
@@ -362,7 +367,9 @@ def _select_reference_model_version(
             metadata["alias_ambiguous"] = len(alias_candidates_sorted) > 1
             selected_alias_version = alias_candidates_sorted[0]
             if metadata["alias_ambiguous"]:
-                metadata["resolution_warning"] = "alias_ambiguous_selected_highest"
+                metadata["resolution_warning"] = (
+                    DriftReferenceResolutionWarning.ALIAS_AMBIGUOUS_SELECTED_HIGHEST.value
+                )
                 logger.warning(
                     "Drift alias '@%s' resolved to %s candidates; selecting highest "
                     "version deterministically (%s).",
@@ -370,14 +377,16 @@ def _select_reference_model_version(
                     len(alias_candidates_sorted),
                     getattr(selected_alias_version, "version", "unknown"),
                 )
-            metadata["resolution_strategy"] = "alias"
+            metadata["resolution_strategy"] = DriftResolutionMode.ALIAS.value
             return selected_alias_version, metadata
         logger.warning(
             "Configured drift reference alias '@%s' not found; "
             "falling back to stage/latest resolution.",
             normalized_alias,
         )
-        metadata["resolution_warning"] = "alias_not_found_fallback"
+        metadata["resolution_warning"] = (
+            DriftReferenceResolutionWarning.ALIAS_NOT_FOUND_FALLBACK.value
+        )
 
     stage_candidates = [
         version
@@ -390,7 +399,9 @@ def _select_reference_model_version(
         )[0]
         metadata["resolution_strategy"] = "production_stage"
         if metadata.get("resolution_warning") is None:
-            metadata["resolution_warning"] = "stage_fallback_used"
+            metadata["resolution_warning"] = (
+                DriftReferenceResolutionWarning.STAGE_FALLBACK_USED.value
+            )
 
         global _DRIFT_STAGE_FALLBACK_WARNED
         if not _DRIFT_STAGE_FALLBACK_WARNED:
@@ -406,7 +417,9 @@ def _select_reference_model_version(
     selected_latest = sorted(versions, key=_safe_model_version_number, reverse=True)[0]
     metadata["resolution_strategy"] = "latest_version"
     if metadata.get("resolution_warning") is None:
-        metadata["resolution_warning"] = "latest_fallback_used"
+        metadata["resolution_warning"] = (
+            DriftReferenceResolutionWarning.LATEST_FALLBACK_USED.value
+        )
 
     global _DRIFT_LATEST_FALLBACK_WARNED
     if not _DRIFT_LATEST_FALLBACK_WARNED:
@@ -456,9 +469,9 @@ def _normalize_reference_resolution_warning(raw_warning: Any) -> str | None:
     if warning is None:
         return None
     warning = warning.lower()
-    if warning not in REFERENCE_RESOLUTION_WARNING_CODES:
-        return None
-    return warning
+    if warning in DRIFT_REFERENCE_RESOLUTION_WARNING_CODES:
+        return warning
+    return _LEGACY_REFERENCE_RESOLUTION_WARNING_CODE_ALIASES.get(warning)
 
 
 def _bounded_metadata_text(value: Any, *, max_len: int) -> str | None:
@@ -550,6 +563,28 @@ def _bounded_optional_text(value: Any, *, max_len: int) -> str | None:
     return text[:max_len]
 
 
+def _normalize_buckettype(raw_buckettype: Any) -> str | None:
+    buckettype = _bounded_optional_text(
+        raw_buckettype, max_len=MAX_DRIFT_BUCKETTYPE_LENGTH
+    )
+    if buckettype is None:
+        return None
+    buckettype = buckettype.lower()
+    if buckettype in DRIFT_BUCKET_TYPES:
+        return buckettype
+    return None
+
+
+def _normalize_bucketing_fallback_reason(raw_reason: Any) -> str | None:
+    reason = _bounded_optional_text(raw_reason, max_len=MAX_DRIFT_ERROR_CODE_LENGTH)
+    if reason is None:
+        return None
+    reason = reason.lower()
+    if reason in DRIFT_FALLBACK_REASONS:
+        return reason
+    return None
+
+
 def _normalize_reference_resolution_metadata(
     raw_resolution: Any,
     *,
@@ -603,23 +638,16 @@ def _normalize_bucketing_metadata(raw_bucketing: Any) -> dict[str, Any]:
                 break
 
     drift_error = _normalize_error_code(metadata.get("drift_error"))
-    if drift_error is None:
-        drift_error = _bounded_error_code(metadata.get("drift_error"))
 
     normalized = {
-        "buckettype_requested": _bounded_optional_text(
-            metadata.get("buckettype_requested"),
-            max_len=MAX_DRIFT_BUCKETTYPE_LENGTH,
+        "buckettype_requested": _normalize_buckettype(
+            metadata.get("buckettype_requested")
         ),
-        "buckettype_used": _bounded_optional_text(
-            metadata.get("buckettype_used"),
-            max_len=MAX_DRIFT_BUCKETTYPE_LENGTH,
-        ),
+        "buckettype_used": _normalize_buckettype(metadata.get("buckettype_used")),
         "buckets_requested": _coerce_int_or_none(metadata.get("buckets_requested")),
         "buckets_used": _coerce_int_or_none(metadata.get("buckets_used")),
-        "bucketing_fallback_reason": _bounded_optional_text(
-            metadata.get("bucketing_fallback_reason"),
-            max_len=MAX_DRIFT_ERROR_CODE_LENGTH,
+        "bucketing_fallback_reason": _normalize_bucketing_fallback_reason(
+            metadata.get("bucketing_fallback_reason")
         ),
         "breakpoints": normalized_breakpoints,
         "reference_sample_size": _coerce_int_or_none(
@@ -705,9 +733,10 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
     results.setdefault("reference_model_version_chosen", None)
     results.setdefault("reference_alias_requested", None)
     results.setdefault("reference_resolution_warning", None)
+    raw_reference_resolution = results.get("reference_resolution")
     raw_resolution_mode = _normalize_resolution_mode(results.get("resolution_mode"))
     reference_resolution = _normalize_reference_resolution_metadata(
-        results.get("reference_resolution"),
+        raw_reference_resolution,
         fallback_mode=raw_resolution_mode,
     )
     normalized_resolution_mode = raw_resolution_mode
@@ -732,7 +761,10 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
         error_message = results.get("error")
     if error_message is None and error_code is not None:
         error_message = _DEFAULT_DRIFT_ERROR_MESSAGES.get(error_code)
-    if error_message is not None:
+    if error_code is None:
+        results["error_message"] = None
+        results["error"] = None
+    elif error_message is not None:
         bounded_error_message = _bounded_error_message(error_message)
         if bounded_error_message:
             results["error_message"] = bounded_error_message
@@ -744,14 +776,8 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
         results["error_message"] = None
         results["error"] = None
 
-    if error_code is not None:
-        results["drift_error"] = error_code
-    else:
-        results["drift_error"] = _normalize_error_code(results.get("drift_error"))
-    if results["drift_error"] is None:
-        results["drift_error"] = _bounded_error_code(results.get("drift_error"))
-
     results["error_code"] = error_code
+    results["drift_error"] = error_code
 
     reference_model_version = _bounded_optional_text(
         results.get("reference_model_version"),
@@ -776,16 +802,22 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
             max_len=MAX_REFERENCE_METADATA_TEXT_LENGTH,
         )
     results["reference_alias_requested"] = requested_alias
+    requested_mode_source = results.get("reference_resolution_mode_requested")
+    if requested_mode_source is None and isinstance(raw_reference_resolution, dict):
+        requested_mode_source = raw_reference_resolution.get("requested_mode")
     requested_mode = _normalize_requested_resolution_mode(
-        results.get("reference_resolution_mode_requested"),
+        requested_mode_source,
         requested_alias=requested_alias,
     )
     results["reference_resolution_mode_requested"] = requested_mode
     results["reference_resolution_mode"] = normalized_resolution_mode
     results["reference_model_version_chosen"] = reference_model_version
 
+    raw_resolution_warning = results.get("reference_resolution_warning")
+    if raw_resolution_warning is None and isinstance(raw_reference_resolution, dict):
+        raw_resolution_warning = raw_reference_resolution.get("resolution_warning")
     reference_resolution_warning = _normalize_reference_resolution_warning(
-        results.get("reference_resolution_warning")
+        raw_resolution_warning
     )
     if (
         reference_resolution_warning is None
@@ -793,13 +825,17 @@ def _finalize_drift_error_contract(results: dict[str, Any]) -> dict[str, Any]:
         and normalized_resolution_mode
         in {DriftResolutionMode.STAGE.value, DriftResolutionMode.LATEST.value}
     ):
-        reference_resolution_warning = "alias_not_found_fallback"
+        reference_resolution_warning = (
+            DriftReferenceResolutionWarning.ALIAS_NOT_FOUND_FALLBACK.value
+        )
     if (
         reference_resolution_warning is None
         and normalized_resolution_mode == DriftResolutionMode.NONE.value
         and reference_model_version is None
     ):
-        reference_resolution_warning = "no_reference_versions_available"
+        reference_resolution_warning = (
+            DriftReferenceResolutionWarning.NO_REFERENCE_VERSIONS_AVAILABLE.value
+        )
     results["reference_resolution_warning"] = reference_resolution_warning
 
     return results
@@ -1023,14 +1059,14 @@ def detect_drift(
                 )
             results["features"][feature] = {
                 "psi": round(psi, 4),
-                "status": "OK",
+                "status": DriftFeatureStatus.OK.value,
                 "drift_error": drift_error,
                 "bucketing": normalized_bucketing,
             }
             continue
 
         if psi >= PSI_THRESHOLD_CRITICAL:
-            status = "CRITICAL"
+            status = DriftFeatureStatus.CRITICAL.value
             results["alerts"].append(
                 {
                     "severity": "critical",
@@ -1045,7 +1081,7 @@ def detect_drift(
                 }
             )
         elif psi >= PSI_THRESHOLD_WARNING:
-            status = "WARNING"
+            status = DriftFeatureStatus.WARNING.value
             results["alerts"].append(
                 {
                     "severity": "warning",
@@ -1060,7 +1096,7 @@ def detect_drift(
                 }
             )
         else:
-            status = "OK"
+            status = DriftFeatureStatus.OK.value
 
         results["features"][feature] = {
             "psi": round(psi, 4),
@@ -1069,7 +1105,7 @@ def detect_drift(
             "bucketing": normalized_bucketing,
         }
 
-        if status == "CRITICAL":
+        if status == DriftFeatureStatus.CRITICAL.value:
             results["drift_detected"] = True
             results["drifted_features"].append(feature)
 

--- a/python/src/training/reason_codes.py
+++ b/python/src/training/reason_codes.py
@@ -52,6 +52,24 @@ class DriftResolutionMode(str, Enum):
     NONE = "none"
 
 
+class DriftReferenceResolutionWarning(str, Enum):
+    """Canonical warning codes describing reference resolution fallback behavior."""
+
+    ALIAS_NOT_FOUND_FALLBACK = "alias_not_found_fallback"
+    ALIAS_AMBIGUOUS_SELECTED_HIGHEST = "alias_ambiguous_selected_highest"
+    STAGE_FALLBACK_USED = "stage_fallback_used"
+    LATEST_FALLBACK_USED = "latest_fallback_used"
+    NO_REFERENCE_VERSIONS_AVAILABLE = "no_reference_versions_available"
+
+
+class DriftFeatureStatus(str, Enum):
+    """Canonical per-feature drift status labels."""
+
+    OK = "OK"
+    WARNING = "WARNING"
+    CRITICAL = "CRITICAL"
+
+
 class BenchmarkStatus(str, Enum):
     """Status codes for inference benchmark execution."""
 
@@ -119,6 +137,10 @@ CALIBRATION_SKIP_REASONS = frozenset(reason.value for reason in CalibrationSkipR
 DRIFT_FALLBACK_REASONS = frozenset(reason.value for reason in DriftFallbackReason)
 DRIFT_ERROR_CODES = frozenset(reason.value for reason in DriftErrorCode)
 DRIFT_RESOLUTION_MODES = frozenset(reason.value for reason in DriftResolutionMode)
+DRIFT_REFERENCE_RESOLUTION_WARNING_CODES = frozenset(
+    reason.value for reason in DriftReferenceResolutionWarning
+)
+DRIFT_FEATURE_STATUSES = frozenset(reason.value for reason in DriftFeatureStatus)
 BENCHMARK_STATUSES = frozenset(reason.value for reason in BenchmarkStatus)
 MODEL_MANAGER_STATES = frozenset(reason.value for reason in ModelManagerState)
 RELOAD_STATUSES = frozenset(reason.value for reason in ReloadStatus)

--- a/python/tests/inference/test_model_manager_diagnostics.py
+++ b/python/tests/inference/test_model_manager_diagnostics.py
@@ -266,6 +266,10 @@ class TestModelManagerDiagnostics:
             "config",
             "warnings",
             "status",
+            "overall_status",
+            "degraded",
+            "has_warnings",
+            "warning_count",
             "state",
             "active_model_version",
             "last_reload_status",
@@ -282,6 +286,10 @@ class TestModelManagerDiagnostics:
         assert health["benchmark_status"] is None
         assert health["warnings"] == ["drift_reference_unavailable"]
         assert health["status"] in OPERABILITY_STATUSES
+        assert health["overall_status"] == health["status"]
+        assert health["degraded"] is False
+        assert health["has_warnings"] is True
+        assert health["warning_count"] == 1
         assert health["drift"]["last_error_code"] is None
         assert health["drift_last_error_code"] is None
         assert health["drift_last_computed_ts"] is None

--- a/python/tests/test_contract_compatibility_guards.py
+++ b/python/tests/test_contract_compatibility_guards.py
@@ -24,6 +24,10 @@ ML_HEALTH_KEYS = {
     "config",
     "warnings",
     "status",
+    "overall_status",
+    "degraded",
+    "has_warnings",
+    "warning_count",
     "state",
     "active_model_version",
     "last_reload_status",
@@ -156,6 +160,10 @@ def test_ml_health_contract_guard_shape_types_and_bounds():
         }
     )
     assert health["status"] in {"success", "failure", "unknown", "not_run"}
+    assert health["overall_status"] == health["status"]
+    assert isinstance(health["degraded"], bool)
+    assert health["has_warnings"] == bool(health["warnings"])
+    assert health["warning_count"] == len(health["warnings"])
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
     assert len(health["active_model_version"]) <= 64

--- a/python/tests/test_detect_drift.py
+++ b/python/tests/test_detect_drift.py
@@ -13,6 +13,7 @@ from training.detect_drift import (
     MIN_REFERENCE_SAMPLES,
     PSI_THRESHOLD_CRITICAL,
     _finalize_drift_error_contract,
+    _normalize_bucketing_metadata,
     calculate_psi,
     detect_drift,
     get_reference_data,
@@ -1209,3 +1210,52 @@ class TestDetectDrift:
 
         assert result["resolution_mode"] == expected_mode
         assert result["reference_resolution_mode"] == expected_mode
+
+    def test_noncanonical_drift_error_is_removed_from_finalized_contract(self):
+        legacy = {
+            "drift_error": "operator_specific_failure_code",
+            "error_code": None,
+            "error_message": "free-form message",
+            "error": "free-form message",
+            "resolution_mode": "none",
+            "reference_model_version": None,
+        }
+
+        result = _finalize_drift_error_contract(legacy)
+
+        assert result["error_code"] is None
+        assert result["drift_error"] is None
+        assert result["error_message"] is None
+        assert result["error"] is None
+
+    def test_reference_resolution_warning_is_hydrated_from_reference_metadata(self):
+        legacy = {
+            "resolution_mode": "stage",
+            "reference_resolution": {
+                "resolution_mode": "stage",
+                "resolution_warning": "stage_fallback_used",
+                "selected_model_version": "7",
+            },
+        }
+
+        result = _finalize_drift_error_contract(legacy)
+
+        assert result["reference_resolution_mode"] == DriftResolutionMode.STAGE.value
+        assert result["reference_resolution_warning"] == "stage_fallback_used"
+        assert result["reference_model_version_chosen"] == "7"
+
+    def test_bucketing_metadata_contract_drops_noncanonical_vocab(self):
+        normalized = _normalize_bucketing_metadata(
+            {
+                "buckettype_requested": "unexpected_bucket_scheme",
+                "buckettype_used": "quantiles",
+                "bucketing_fallback_reason": "custom_fallback_reason",
+                "drift_error": "custom_drift_error",
+                "breakpoints": [0, 1, 2],
+            }
+        )
+
+        assert normalized["buckettype_requested"] is None
+        assert normalized["buckettype_used"] == "quantiles"
+        assert normalized["bucketing_fallback_reason"] is None
+        assert normalized["drift_error"] is None

--- a/python/tests/test_model_manager_defaults.py
+++ b/python/tests/test_model_manager_defaults.py
@@ -118,6 +118,10 @@ def test_ml_health_summary_is_stable_and_bounded():
         "config",
         "warnings",
         "status",
+        "overall_status",
+        "degraded",
+        "has_warnings",
+        "warning_count",
         "state",
         "active_model_version",
         "last_reload_status",
@@ -157,6 +161,10 @@ def test_ml_health_summary_is_stable_and_bounded():
     assert isinstance(health["state"], str)
     assert isinstance(health["warnings"], list)
     assert health["status"] in OPERABILITY_STATUSES
+    assert health["overall_status"] == health["status"]
+    assert isinstance(health["degraded"], bool)
+    assert health["has_warnings"] == bool(health["warnings"])
+    assert health["warning_count"] == len(health["warnings"])
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
     assert health["last_reload_ts"] is None or isinstance(

--- a/python/tests/test_obs_contract_compatibility.py
+++ b/python/tests/test_obs_contract_compatibility.py
@@ -23,6 +23,10 @@ ML_HEALTH_REQUIRED_KEYS = {
     "config",
     "warnings",
     "status",
+    "overall_status",
+    "degraded",
+    "has_warnings",
+    "warning_count",
     "state",
     "active_model_version",
     "last_reload_status",
@@ -132,6 +136,10 @@ def _assert_ml_health_contract(health: dict) -> None:
         }
     )
     assert health["status"] in {"success", "failure", "unknown", "not_run"}
+    assert health["overall_status"] == health["status"]
+    assert isinstance(health["degraded"], bool)
+    assert health["has_warnings"] == bool(health["warnings"])
+    assert health["warning_count"] == len(health["warnings"])
     assert isinstance(health["active_model_version"], str)
     assert isinstance(health["last_reload_status"], str)
     assert isinstance(health["schema_mismatch_detected"], bool)

--- a/python/tests/test_obs_contract_compatibility_v8.py
+++ b/python/tests/test_obs_contract_compatibility_v8.py
@@ -1,0 +1,337 @@
+"""Compatibility guards for diagnostics + drift payload contracts (v8 tranche)."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+from forecast.model_manager import ModelManager
+from training.detect_drift import MIN_REFERENCE_SAMPLES, detect_drift
+from training.reason_codes import (
+    BENCHMARK_STATUSES,
+    DIAGNOSTICS_DEGRADED_REASONS,
+    DIAGNOSTICS_WARNING_CODES,
+    DRIFT_ERROR_CODES,
+    DRIFT_FALLBACK_REASONS,
+    DRIFT_FEATURE_STATUSES,
+    DRIFT_REFERENCE_RESOLUTION_WARNING_CODES,
+    DRIFT_RESOLUTION_MODES,
+    MODEL_MANAGER_STATES,
+    OPERABILITY_STATUSES,
+    RELOAD_FAILURE_REASONS,
+    RELOAD_STATUSES,
+)
+
+DIAGNOSTICS_KEYS = {
+    "status",
+    "state",
+    "model_version",
+    "model_source",
+    "last_error",
+    "schema_mismatch_detected",
+    "calibrator_loaded",
+    "has_bundle",
+    "last_reload_ts",
+    "last_reload_status",
+    "last_reload_reason",
+    "benchmark_last_run_ts",
+    "benchmark_last_status",
+    "degraded_reasons",
+    "active_model_version",
+    "feature_coverage_warning_active",
+    "feature_coverage_last_ratio",
+    "feature_coverage_warning_last_seen_ts",
+    "ml.training.run_id",
+    "ml.model.version",
+    "ml.feature.schema_hash",
+    "config",
+    "warnings",
+    "ml_health",
+}
+
+ML_HEALTH_KEYS = {
+    "model",
+    "benchmark",
+    "drift",
+    "feature_coverage",
+    "config",
+    "warnings",
+    "status",
+    "overall_status",
+    "degraded",
+    "has_warnings",
+    "warning_count",
+    "state",
+    "active_model_version",
+    "last_reload_status",
+    "last_reload_ts",
+    "schema_mismatch_detected",
+    "benchmark_status",
+    "feature_coverage_status",
+    "feature_coverage_last_seen_ts",
+    "drift_reference_available",
+    "drift_resolution_mode",
+    "drift_last_computed_ts",
+    "drift_last_error_code",
+}
+
+DRIFT_KEYS = {
+    "timestamp",
+    "hours_analyzed",
+    "threshold",
+    "reference_size",
+    "live_size",
+    "features",
+    "drift_detected",
+    "drifted_features",
+    "drift_error",
+    "error_code",
+    "error_message",
+    "error",
+    "resolution_mode",
+    "alerts",
+    "reference_resolution",
+    "reference_model_version",
+    "reference_resolution_mode_requested",
+    "reference_resolution_mode",
+    "reference_model_version_chosen",
+    "reference_alias_requested",
+    "reference_resolution_warning",
+}
+
+DRIFT_REFERENCE_KEYS = {
+    "requested_alias",
+    "resolution_strategy",
+    "resolution_mode",
+    "alias_candidate_count",
+    "alias_ambiguous",
+    "selected_model_version",
+    "selected_run_id",
+}
+
+DRIFT_FEATURE_KEYS = {"psi", "status", "drift_error", "bucketing"}
+DRIFT_BUCKETING_KEYS = {
+    "buckettype_requested",
+    "buckettype_used",
+    "buckets_requested",
+    "buckets_used",
+    "bucketing_fallback_reason",
+    "breakpoints",
+    "reference_sample_size",
+    "nonempty_buckets",
+    "nonempty_buckets_ratio",
+    "min_expected_count",
+    "bucket_mass_ok",
+    "bucket_mass_guardrail_applied",
+    "drift_error",
+}
+
+
+def _fresh_manager() -> ModelManager:
+    ModelManager._instance = None
+    return ModelManager()
+
+
+def _stable_frame(size: int = 1000) -> pd.DataFrame:
+    base = np.arange(size, dtype=float)
+    return pd.DataFrame(
+        {
+            "velocity_24h": base,
+            "amount_to_avg_ratio_30d": base * 0.5,
+            "balance_volatility_z_score": base - 250.0,
+        }
+    )
+
+
+def test_v8_diagnostics_contract_keys_and_summary_shape_are_stable():
+    manager = _fresh_manager()
+    manager._schema_mismatch_detected = True
+    manager._model_source = "fallback"
+    manager.update_feature_coverage_warning(active=True, observed_ts=111.5, ratio=0.4)
+    mock_cache = SimpleNamespace(
+        _cache=SimpleNamespace(
+            computed_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            result={
+                "resolution_mode": "none",
+                "error_code": "no_reference_data",
+            },
+        )
+    )
+
+    with patch("forecast.drift_cache.get_drift_cache", return_value=mock_cache):
+        diagnostics = manager.get_diagnostics()
+
+    assert set(diagnostics.keys()) == DIAGNOSTICS_KEYS
+    assert diagnostics["state"] in MODEL_MANAGER_STATES
+    assert diagnostics["status"] in OPERABILITY_STATUSES
+    assert diagnostics["last_reload_status"] in RELOAD_STATUSES
+    assert diagnostics["last_reload_reason"] in RELOAD_FAILURE_REASONS | {None}
+    assert diagnostics["benchmark_last_status"] in BENCHMARK_STATUSES | {None}
+    assert set(diagnostics["warnings"]).issubset(DIAGNOSTICS_WARNING_CODES)
+    assert set(diagnostics["degraded_reasons"]).issubset(DIAGNOSTICS_DEGRADED_REASONS)
+
+    health = diagnostics["ml_health"]
+    assert set(health.keys()) == ML_HEALTH_KEYS
+    assert health["overall_status"] == health["status"]
+    assert health["status"] in OPERABILITY_STATUSES
+    assert health["has_warnings"] == bool(health["warnings"])
+    assert health["warning_count"] == len(health["warnings"])
+    assert health["degraded"] == (
+        bool(diagnostics["degraded_reasons"])
+        or health["overall_status"] in {"failure", "unknown"}
+    )
+
+
+@patch("training.detect_drift.get_reference_data")
+@patch("training.detect_drift.get_live_data")
+def test_v8_drift_contract_shape_and_vocab_across_reference_error_modes(
+    mock_live,
+    mock_ref,
+):
+    stable = _stable_frame()
+    sparse_size = MIN_REFERENCE_SAMPLES + 20
+    sparse_reference = np.array([0.0] * (sparse_size - 10) + [1.0] * 10)
+    sparse_live = np.array([0.0] * (sparse_size - 30) + [8.0] * 30)
+
+    scenarios = [
+        {
+            "name": "success_alias",
+            "reference": (
+                stable,
+                {
+                    "requested_alias": "champion",
+                    "requested_mode": "alias",
+                    "resolution_strategy": "alias",
+                    "selected_model_version": "9",
+                    "selected_run_id": "run-v9",
+                },
+            ),
+            "live": stable.copy(),
+            "error_code": None,
+            "resolution_mode": "alias",
+            "resolution_warning": None,
+        },
+        {
+            "name": "alias_fallback",
+            "reference": (
+                stable,
+                {
+                    "requested_alias": "champion",
+                    "requested_mode": "alias",
+                    "resolution_strategy": "production_stage",
+                    "selected_model_version": "7",
+                    "selected_run_id": "run-v7",
+                    "resolution_warning": "alias_not_found_fallback",
+                },
+            ),
+            "live": stable.copy(),
+            "error_code": None,
+            "resolution_mode": "stage",
+            "resolution_warning": "alias_not_found_fallback",
+        },
+        {
+            "name": "no_reference",
+            "reference": (
+                None,
+                {
+                    "requested_alias": "champion",
+                    "requested_mode": "alias",
+                    "resolution_warning": "no_reference_versions_available",
+                },
+            ),
+            "live": pd.DataFrame(),
+            "error_code": "no_reference_data",
+            "resolution_mode": "none",
+            "resolution_warning": "no_reference_versions_available",
+        },
+        {
+            "name": "insufficient_reference",
+            "reference": _stable_frame(size=50),
+            "live": pd.DataFrame(),
+            "error_code": "insufficient_reference_samples",
+            "resolution_mode": "none",
+            "resolution_warning": "no_reference_versions_available",
+        },
+        {
+            "name": "suppressed_bucket_mass",
+            "reference": pd.DataFrame(
+                {
+                    "velocity_24h": sparse_reference,
+                    "amount_to_avg_ratio_30d": sparse_reference,
+                    "balance_volatility_z_score": sparse_reference,
+                }
+            ),
+            "live": pd.DataFrame(
+                {
+                    "velocity_24h": sparse_live,
+                    "amount_to_avg_ratio_30d": sparse_live,
+                    "balance_volatility_z_score": sparse_live,
+                }
+            ),
+            "error_code": "insufficient_bucket_mass",
+            "resolution_mode": "none",
+            "resolution_warning": "no_reference_versions_available",
+        },
+    ]
+
+    for scenario in scenarios:
+        mock_ref.return_value = scenario["reference"]
+        mock_live.return_value = scenario["live"]
+
+        result = detect_drift()
+
+        assert set(result.keys()) == DRIFT_KEYS, scenario["name"]
+        assert isinstance(result["timestamp"], str), scenario["name"]
+        assert result["resolution_mode"] in DRIFT_RESOLUTION_MODES, scenario["name"]
+        assert result["reference_resolution_mode"] == result["resolution_mode"], (
+            scenario["name"]
+        )
+        assert (
+            result["reference_resolution_mode_requested"] in DRIFT_RESOLUTION_MODES
+        ), scenario["name"]
+        assert result["error_code"] == scenario["error_code"], scenario["name"]
+        assert result["resolution_mode"] == scenario["resolution_mode"], scenario[
+            "name"
+        ]
+        assert (
+            result["reference_resolution_warning"] == scenario["resolution_warning"]
+        ), scenario["name"]
+
+        assert set(result["reference_resolution"].keys()) == DRIFT_REFERENCE_KEYS
+        assert (
+            result["reference_resolution"]["resolution_mode"] in DRIFT_RESOLUTION_MODES
+        )
+        assert (
+            result["reference_resolution"]["resolution_strategy"]
+            in DRIFT_RESOLUTION_MODES
+        )
+
+        assert result[
+            "reference_resolution_warning"
+        ] in DRIFT_REFERENCE_RESOLUTION_WARNING_CODES | {None}
+        assert result["drift_error"] in DRIFT_ERROR_CODES | {None}
+        if result["error_code"] is None:
+            assert result["error_message"] is None
+            assert result["error"] is None
+            assert result["drift_error"] is None
+        else:
+            assert result["drift_error"] == result["error_code"]
+            assert result["error_message"] is not None
+            assert result["error"] == result["error_message"]
+
+        for feature_result in result["features"].values():
+            assert set(feature_result.keys()) == DRIFT_FEATURE_KEYS
+            assert feature_result["status"] in DRIFT_FEATURE_STATUSES
+            assert set(feature_result["bucketing"].keys()) == DRIFT_BUCKETING_KEYS
+            assert feature_result["drift_error"] in DRIFT_ERROR_CODES | {None}
+
+            bucketing = feature_result["bucketing"]
+            assert bucketing["buckettype_requested"] in {"bins", "quantiles", None}
+            assert bucketing["buckettype_used"] in {"bins", "quantiles", None}
+            assert bucketing["bucketing_fallback_reason"] in (
+                DRIFT_FALLBACK_REASONS | {None}
+            )
+            assert bucketing["drift_error"] in DRIFT_ERROR_CODES | {None}
+            break

--- a/python/tests/test_obs_payload_canonicalization.py
+++ b/python/tests/test_obs_payload_canonicalization.py
@@ -47,6 +47,10 @@ _ML_HEALTH_KEYS = {
     "config",
     "warnings",
     "status",
+    "overall_status",
+    "degraded",
+    "has_warnings",
+    "warning_count",
     "state",
     "active_model_version",
     "last_reload_status",
@@ -157,3 +161,6 @@ def test_ml_health_summary_canonicalizes_optional_fields_and_scalar_types():
     assert health["feature_coverage"]["last_ratio"] == 0.0
     assert health["feature_coverage"]["below_threshold"] is True
     assert health["warnings"] == ["feature_coverage_below_threshold"]
+    assert health["overall_status"] == health["status"]
+    assert health["has_warnings"] is True
+    assert health["warning_count"] == len(health["warnings"]) == 1

--- a/python/tests/test_obs_payload_canonicalization.py
+++ b/python/tests/test_obs_payload_canonicalization.py
@@ -1,0 +1,159 @@
+"""Canonicalization guards for diagnostics + ml_health payload fields."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from forecast.model_manager import ModelManager
+from training.reason_codes import (
+    BENCHMARK_STATUSES,
+    MODEL_MANAGER_STATES,
+    OPERABILITY_STATUSES,
+    RELOAD_FAILURE_REASONS,
+    RELOAD_STATUSES,
+)
+
+_DIAGNOSTICS_KEYS = {
+    "status",
+    "state",
+    "model_version",
+    "model_source",
+    "last_error",
+    "schema_mismatch_detected",
+    "calibrator_loaded",
+    "has_bundle",
+    "last_reload_ts",
+    "last_reload_status",
+    "last_reload_reason",
+    "benchmark_last_run_ts",
+    "benchmark_last_status",
+    "degraded_reasons",
+    "active_model_version",
+    "feature_coverage_warning_active",
+    "feature_coverage_last_ratio",
+    "feature_coverage_warning_last_seen_ts",
+    "ml.training.run_id",
+    "ml.model.version",
+    "ml.feature.schema_hash",
+    "config",
+    "warnings",
+    "ml_health",
+}
+
+_ML_HEALTH_KEYS = {
+    "model",
+    "benchmark",
+    "drift",
+    "feature_coverage",
+    "config",
+    "warnings",
+    "status",
+    "state",
+    "active_model_version",
+    "last_reload_status",
+    "last_reload_ts",
+    "schema_mismatch_detected",
+    "benchmark_status",
+    "feature_coverage_status",
+    "feature_coverage_last_seen_ts",
+    "drift_reference_available",
+    "drift_resolution_mode",
+    "drift_last_computed_ts",
+    "drift_last_error_code",
+}
+
+
+def _fresh_manager() -> ModelManager:
+    ModelManager._instance = None
+    return ModelManager()
+
+
+def test_diagnostics_payload_keys_types_and_bounds_are_canonical():
+    manager = _fresh_manager()
+    manager._state = "INVALID-STATE-" * 20
+    manager._model_version = "v" * 300
+    manager._model_source = "external-source-name" * 20
+    manager._last_error = "error-" * 80
+    manager._mlflow_failure_reason = "unknown-failure-with-extra-context" * 10
+    manager._feature_coverage_warning_active = "yes"
+    manager._feature_coverage_last_ratio = "1.7"
+    manager._feature_coverage_warning_last_seen_ts = "not-a-float"
+    manager._benchmark_last_status = "benchmark failed for detailed operator reason"
+    manager._training_identity = {
+        "mlflow_run_id": "r" * 300,
+        "model_version": "m" * 300,
+        "feature_schema_hash": "h" * 300,
+    }
+
+    diagnostics = manager.get_diagnostics()
+
+    assert set(diagnostics.keys()) == _DIAGNOSTICS_KEYS
+    assert diagnostics["state"] in MODEL_MANAGER_STATES
+    assert diagnostics["status"] in OPERABILITY_STATUSES
+    assert diagnostics["last_reload_status"] in RELOAD_STATUSES
+    assert diagnostics["benchmark_last_status"] in BENCHMARK_STATUSES | {None}
+    assert diagnostics["model_source"] in {"mlflow", "fallback", "none"}
+    assert diagnostics["last_reload_reason"] in RELOAD_FAILURE_REASONS | {None}
+
+    assert isinstance(diagnostics["warnings"], list)
+    assert isinstance(diagnostics["degraded_reasons"], list)
+    assert isinstance(diagnostics["schema_mismatch_detected"], bool)
+    assert isinstance(diagnostics["feature_coverage_warning_active"], bool)
+    assert diagnostics["feature_coverage_warning_active"] is True
+
+    assert isinstance(diagnostics["model_version"], str)
+    assert isinstance(diagnostics["active_model_version"], str)
+    assert len(diagnostics["model_version"]) <= 64
+    assert len(diagnostics["active_model_version"]) <= 64
+    assert diagnostics["feature_coverage_last_ratio"] == 1.0
+    assert diagnostics["feature_coverage_warning_last_seen_ts"] is None
+    assert diagnostics["last_error"] is not None
+    assert len(diagnostics["last_error"]) <= 200
+    assert len(diagnostics["ml.training.run_id"]) <= 128
+    assert len(diagnostics["ml.model.version"]) <= 64
+    assert len(diagnostics["ml.feature.schema_hash"]) <= 128
+
+
+def test_ml_health_summary_canonicalizes_optional_fields_and_scalar_types():
+    manager = _fresh_manager()
+    snapshot = {
+        "state": "unexpected_state_value",
+        "status": "not-a-real-status",
+        "active_model_version": "v" * 400,
+        "last_reload_status": "reload-status-" * 30,
+        "last_reload_ts": "nan",
+        "schema_mismatch_detected": "yes",
+        "benchmark_last_status": "not-a-status",
+        "benchmark_last_run_ts": "not-a-float",
+        "feature_coverage_warning_active": "true",
+        "feature_coverage_last_ratio": -2.0,
+        "feature_coverage_warning_last_seen_ts": "not-a-float",
+        "warnings": [
+            "feature_coverage_below_threshold",
+            "ad-hoc operator warning text",
+            "",
+        ],
+        "config": {
+            "strict_feature_schema": "1",
+            "strict_tuning_resume_validation": "0",
+            "strict_split_strategy_validation": 1,
+        },
+    }
+
+    with patch(
+        "forecast.drift_cache.get_drift_cache",
+        return_value=SimpleNamespace(_cache=None),
+    ):
+        health = manager._build_ml_health_summary(snapshot)
+
+    assert set(health.keys()) == _ML_HEALTH_KEYS
+    assert health["state"] in MODEL_MANAGER_STATES
+    assert health["status"] in OPERABILITY_STATUSES
+    assert len(health["active_model_version"]) <= 64
+    assert len(health["last_reload_status"]) <= 32
+    assert health["benchmark"]["last_status"] == "unknown"
+    assert health["benchmark"]["last_run_ts"] is None
+    assert health["last_reload_ts"] is None
+    assert health["feature_coverage_last_seen_ts"] is None
+    assert health["feature_coverage"]["last_ratio"] == 0.0
+    assert health["feature_coverage"]["below_threshold"] is True
+    assert health["warnings"] == ["feature_coverage_below_threshold"]

--- a/python/tests/test_obs_payload_shapes_golden.py
+++ b/python/tests/test_obs_payload_shapes_golden.py
@@ -49,6 +49,10 @@ def test_ml_health_payload_golden_shape_and_bounds():
         "config",
         "warnings",
         "status",
+        "overall_status",
+        "degraded",
+        "has_warnings",
+        "warning_count",
         "state",
         "active_model_version",
         "last_reload_status",
@@ -77,6 +81,10 @@ def test_ml_health_payload_golden_shape_and_bounds():
     assert set(health["feature_coverage"].keys()) == {"last_ratio", "below_threshold"}
     assert isinstance(health["warnings"], list)
     assert health["status"] in {"success", "failure", "unknown", "not_run"}
+    assert health["overall_status"] == health["status"]
+    assert isinstance(health["degraded"], bool)
+    assert health["has_warnings"] == bool(health["warnings"])
+    assert health["warning_count"] == len(health["warnings"])
     assert health["state"] in {"idle", "loading", "ready", "failed"}
     assert len(health["active_model_version"]) <= 64
     assert len(health["last_reload_status"]) <= 32

--- a/python/tests/test_obs_summary_consistency.py
+++ b/python/tests/test_obs_summary_consistency.py
@@ -1,0 +1,66 @@
+"""Operator summary consistency guards for diagnostics payloads."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from forecast.model_manager import ModelManager
+from training.reason_codes import ModelManagerState
+
+
+def _fresh_manager() -> ModelManager:
+    ModelManager._instance = None
+    return ModelManager()
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_status", "expected_degraded"),
+    [
+        (ModelManagerState.IDLE.value, "not_run", False),
+        (ModelManagerState.LOADING.value, "unknown", True),
+        (ModelManagerState.READY.value, "success", False),
+        (ModelManagerState.FAILED.value, "failure", True),
+    ],
+)
+def test_summary_overall_status_and_degraded_are_deterministic(
+    state,
+    expected_status,
+    expected_degraded,
+):
+    manager = _fresh_manager()
+    manager._state = state
+
+    diagnostics = manager.get_diagnostics()
+    health = diagnostics["ml_health"]
+
+    assert health["status"] == expected_status
+    assert health["overall_status"] == expected_status
+    assert health["degraded"] == expected_degraded
+    assert health["degraded"] == (
+        bool(diagnostics["degraded_reasons"])
+        or health["overall_status"] in {"failure", "unknown"}
+    )
+
+
+def test_summary_warning_flags_match_warnings_payload_exactly():
+    manager = _fresh_manager()
+    manager._schema_mismatch_detected = True
+    manager._model_source = "fallback"
+    manager.update_feature_coverage_warning(active=True, observed_ts=111.0, ratio=0.5)
+    mock_cache = SimpleNamespace(
+        _cache=SimpleNamespace(
+            computed_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            result={"resolution_mode": "none"},
+        )
+    )
+
+    with patch("forecast.drift_cache.get_drift_cache", return_value=mock_cache):
+        diagnostics = manager.get_diagnostics()
+
+    health = diagnostics["ml_health"]
+    assert health["warnings"] == diagnostics["warnings"]
+    assert health["has_warnings"] is True
+    assert health["warning_count"] == len(health["warnings"])
+    assert health["warning_count"] == 4

--- a/python/tests/test_operability_contract_shapes.py
+++ b/python/tests/test_operability_contract_shapes.py
@@ -53,6 +53,10 @@ def test_ml_health_contract_shape_and_bounds():
         "config",
         "warnings",
         "status",
+        "overall_status",
+        "degraded",
+        "has_warnings",
+        "warning_count",
         "state",
         "active_model_version",
         "last_reload_status",
@@ -87,6 +91,10 @@ def test_ml_health_contract_shape_and_bounds():
     assert set(health["feature_coverage"].keys()) == {"last_ratio", "below_threshold"}
     assert isinstance(health["warnings"], list)
     assert health["status"] in {"success", "failure", "unknown", "not_run"}
+    assert health["overall_status"] == health["status"]
+    assert isinstance(health["degraded"], bool)
+    assert health["has_warnings"] == bool(health["warnings"])
+    assert health["warning_count"] == len(health["warnings"])
     assert isinstance(health["model"]["state"], str)
     assert isinstance(health["model"]["active_model_version"], str)
     assert isinstance(health["model"]["last_reload_status"], str)


### PR DESCRIPTION
## Summary
- canonicalize diagnostics payload field presence/types and bounded strings
- refine operator summary derivation from canonical diagnostics fields
- finalize drift contract reference/error metadata semantics and canonical vocab usage
- strengthen compatibility guards and synchronize docs with runtime payloads

## Verification
- uv run pytest -q
